### PR TITLE
From wgpu-sandbox to ikari: project renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7724808837b77f4b4de9d283820f9d98bcf496d5692934b857a2399d31ff22e6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 dependencies = [
  "backtrace",
 ]
@@ -1011,6 +1011,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "ikari"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cgmath",
+ "console",
+ "cpal",
+ "env_logger",
+ "gltf",
+ "half",
+ "hound",
+ "image",
+ "lazy_static",
+ "log",
+ "minimp3",
+ "obj-rs",
+ "oddio",
+ "pollster",
+ "profiling",
+ "rand",
+ "rapier3d",
+ "twox-hash",
+ "wavefront_obj",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
 name = "image"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d89e5dba24725ae5678020bf8f1357a9aa7ff10736b551adbcd3f8d17d766f"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -1897,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d0f47a940e895261e77dc200d5eadfc6ef644c179c6f5edfc105e3a2292c8"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2170,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8778cc0b528968fe72abec38b5db5a20a70d148116cd9325d2bc5f5180ca3faf"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -2382,9 +2411,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee3a69cd2c7e06684677e5629b3878b253af05e4714964204279c6bc02cf0b"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2866,35 +2895,6 @@ dependencies = [
  "web-sys",
  "wgpu-types",
  "winapi",
-]
-
-[[package]]
-name = "wgpu-sandbox"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytemuck",
- "cgmath",
- "console",
- "cpal",
- "env_logger",
- "gltf",
- "half",
- "hound",
- "image",
- "lazy_static",
- "log",
- "minimp3",
- "obj-rs",
- "oddio",
- "pollster",
- "profiling",
- "rand",
- "rapier3d",
- "twox-hash",
- "wavefront_obj",
- "wgpu",
- "winit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "wgpu-sandbox"
+name = "ikari"
 version = "0.1.0"
-authors = ["https://github.com/Davidster/wgpu-sandbox/graphs/contributors"]
+authors = ["https://github.com/Davidster/ikari/graphs/contributors"]
 edition = "2021"
 rust-version = "1.65"
 description = "3D renderer that will be used to make a simple first person shooter"
-repository = "https://github.com/Davidster/wgpu-sandbox"
+repository = "https://github.com/Davidster/ikari"
 license = "MIT"
 keywords = ["renderer", "first person shooter", "3D", "rust", "wgpu", "game"]
 categories = ["rendering", "game framework", "gamedev"]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ https://user-images.githubusercontent.com/2389735/180101651-86ba2084-4196-494b-9
 - [x] make the logger be a global variable, no need to pass it around everywhere
 - [ ] frustum culling
 - [ ] is there a bug with From<Mat4> for Transform? Seems the base matrix should be updatable?
-- [ ] [optimize shadows](https://github.com/Davidster/wgpu-sandbox/discussions/6)
+- [ ] [optimize shadows](https://github.com/Davidster/ikari/discussions/6)
 - [ ] spawn enemies, make them follow the character
 - [ ] add UI
 - [ ] track score and health, display on screen, and end game when health reaches 0
@@ -101,10 +101,10 @@ https://user-images.githubusercontent.com/2389735/180101651-86ba2084-4196-494b-9
 - [ ] use limit constraints at device creation time to try to lower the min_storage_buffer_offset_alignment number cuz smaller buffer = more cache hits
 
 ## Profiling
-You can profile wgpu-sandbox with [tracy](https://github.com/wolfpld/tracy) via [profiling](https://github.com/aclysma/profiling) crate.
+You can profile ikari with [tracy](https://github.com/wolfpld/tracy) via [profiling](https://github.com/aclysma/profiling) crate.
 To do that you have to:
 - Download [tracy 0.9](https://github.com/wolfpld/tracy/releases/tag/v0.9)
-- Build wgpu-sandbox by adding --features="profile-with-tracy" to the cargo command
+- Build ikari by adding --features="profile-with-tracy" to the cargo command
 - Run wgpubox and tracy (in any order), when the game is loading tracy will start profiling
 
 If something does not work it is possible that the crate profiling has been updated and is no longer aligned with the tracy version and a more recent one must be used.


### PR DESCRIPTION
you may have problems compiling as ikari with the same IDE configuration and cache, try renaming the project or cargo clean-ing as appropriate (or temporarily rename wgpu-sandbox to the package name in cargo.toml to do this work)