### PR TITLE
Optimize node transform computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,15 +76,6 @@ dependencies = [
 
 [[package]]
 name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -285,16 +276,6 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cgmath"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
-dependencies = [
- "approx 0.4.0",
- "num-traits",
-]
 
 [[package]]
 name = "clang-sys"
@@ -865,6 +846,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+dependencies = [
+ "approx",
+ "bytemuck",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+checksum = "6c467d36af040b7b2681f5fddd27427f6da8d3d072f575a265e181d2f8e8d157"
 dependencies = [
  "crunchy",
 ]
@@ -1014,11 +1005,12 @@ name = "ikari"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx",
  "bytemuck",
- "cgmath",
  "console",
  "cpal",
  "env_logger",
+ "glam",
  "gltf",
  "half",
  "hound",
@@ -1433,7 +1425,7 @@ version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -1574,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1758,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "optional"
@@ -1803,7 +1795,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee763b47e68f62d578bcfc3f83cf75d9d970aed5df20b6d90287ca9b3195155d"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "arrayvec 0.7.2",
  "bitflags",
  "downcast-rs",
@@ -1975,7 +1967,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9cc332c8953b5a33e86cacda7466a433a38064825175be8ddd2bc631d858115"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "arrayvec 0.7.2",
  "bit-vec",
  "bitflags",
@@ -2265,7 +2257,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-complex",
  "num-traits",
  "paste",
@@ -2328,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333b8c21ebd9a45c5e955f3d7a1f0c4a2214847dd7e8e1abb69f34ec9b88882d"
+checksum = "1190e0e8f4eb17fc3dbb2d20e1142676e56aaac3daede39f64a3302d687b80f3"
 dependencies = [
  "num-traits",
  "optional",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,10 @@ wgpu = "0.14"
 winit = "0.27"
 
 # math
-cgmath = "0.18"
 rand = "0.8"
 rapier3d = "0.16"
+glam = { version = "0.22.0", features = ["approx", "bytemuck"] }
+approx = "0.5.1"
 
 # audio
 cpal = "0.14"
@@ -65,4 +66,4 @@ opt-level = 0
 [profile.release]
 incremental = false
 codegen-units = 1
-# debug = true
+debug = true

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Mul};
 
-use cgmath::{Quaternion, Vector3};
+use glam::f32::{Quat, Vec3};
 
 use super::*;
 
@@ -57,9 +57,9 @@ struct KeyframeTime {
 
 pub fn step_animations(scene: &mut Scene, delta_time_seconds: f32) {
     pub enum Op {
-        Translation(Vector3<f32>),
-        Scale(Vector3<f32>),
-        Rotation(Quaternion<f32>),
+        Translation(Vec3),
+        Scale(Vec3),
+        Rotation(Quat),
     }
 
     let mut ops: Vec<(GameNodeId, Op)> = Vec::new();
@@ -141,13 +141,13 @@ fn get_vec3_at_moment(
     animation_time_seconds: f32,
     previous_keyframe: Option<KeyframeTime>,
     next_keyframe: Option<KeyframeTime>,
-) -> Vector3<f32> {
+) -> Vec3 {
     let get_basic_keyframe_values = || {
         bytemuck::cast_slice::<_, [f32; 3]>(&channel.keyframe_values_u8)
             .to_vec()
             .iter()
             .copied()
-            .map(Vector3::from)
+            .map(Vec3::from)
             .collect::<Vec<_>>()
     };
     let get_cubic_keyframe_values = || {
@@ -157,9 +157,9 @@ fn get_vec3_at_moment(
             .copied()
             .map(|kf| {
                 [
-                    Vector3::from(kf[0]), // in-tangent
-                    Vector3::from(kf[1]), // value
-                    Vector3::from(kf[2]), // out-tangent
+                    Vec3::from(kf[0]), // in-tangent
+                    Vec3::from(kf[1]), // value
+                    Vec3::from(kf[2]), // out-tangent
                 ]
             })
             .collect::<Vec<_>>()
@@ -219,13 +219,13 @@ fn get_quat_at_moment(
     animation_time_seconds: f32,
     previous_keyframe: Option<KeyframeTime>,
     next_keyframe: Option<KeyframeTime>,
-) -> Quaternion<f32> {
+) -> Quat {
     let get_basic_keyframe_values = || {
         bytemuck::cast_slice::<_, [f32; 4]>(&channel.keyframe_values_u8)
             .to_vec()
             .iter()
             .copied()
-            .map(Quaternion::from)
+            .map(Quat::from_array)
             .collect::<Vec<_>>()
     };
     let get_cubic_keyframe_values = || {
@@ -235,9 +235,9 @@ fn get_quat_at_moment(
             .copied()
             .map(|kf| {
                 [
-                    Quaternion::from(kf[0]), // in-tangent
-                    Quaternion::from(kf[1]), // value
-                    Quaternion::from(kf[2]), // out-tangent
+                    Quat::from_array(kf[0]), // in-tangent
+                    Quat::from_array(kf[1]), // value
+                    Quat::from_array(kf[2]), // out-tangent
                 ]
             })
             .collect::<Vec<_>>()

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use cgmath::Vector3;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
     Stream,
 };
+use glam::f32::Vec3;
 use hound::{WavReader, WavSpec};
 use oddio::{
     FixedGain, FramesSignal, Gain, Handle, Mixer, SpatialBuffered, SpatialOptions, SpatialScene,
@@ -44,8 +44,8 @@ pub enum SoundSignal {
 }
 
 pub struct SpacialParams {
-    initial_position: Vector3<f32>,
-    initial_velocity: Vector3<f32>,
+    initial_position: Vec3,
+    initial_velocity: Vec3,
 }
 
 impl AudioManager {
@@ -374,7 +374,7 @@ impl Sound {
         }
     }
 
-    fn _set_motion(&mut self, position: Vector3<f32>, velocity: Vector3<f32>, discontinuity: bool) {
+    fn _set_motion(&mut self, position: Vec3, velocity: Vec3, discontinuity: bool) {
         if let SoundSignal::Spacial { signal_handle } = &mut self.signal {
             signal_handle.control::<SpatialBuffered<_>, _>().set_motion(
                 [position.x, position.y, position.z].into(),

--- a/src/ball.rs
+++ b/src/ball.rs
@@ -1,28 +1,28 @@
-use cgmath::{Rad, Vector2, Vector3};
+use glam::f32::{Vec2, Vec3};
 
 use super::*;
 
 #[derive(Clone, Debug)]
 pub struct BallComponent {
     pub transform: crate::transform::Transform,
-    direction: Vector3<f32>,
+    direction: Vec3,
     speed: f32,
     radius: f32,
 }
 
 impl BallComponent {
-    pub fn new(position: Vector2<f32>, direction: Vector2<f32>, radius: f32, speed: f32) -> Self {
+    pub fn new(position: Vec2, direction: Vec2, radius: f32, speed: f32) -> Self {
         let transform = TransformBuilder::new()
-            .position(Vector3::new(position.x, radius, position.y))
-            .scale(Vector3::new(radius, radius, radius))
+            .position(Vec3::new(position.x, radius, position.y))
+            .scale(Vec3::new(radius, radius, radius))
             .build();
-        let Vector2 {
+        let Vec2 {
             x: direction_x,
             y: direction_z,
         } = direction;
         Self {
             transform,
-            direction: Vector3::new(direction_x, 0.0, direction_z).normalize(),
+            direction: Vec3::new(direction_x, 0.0, direction_z).normalize(),
             speed,
             radius,
         }
@@ -30,11 +30,11 @@ impl BallComponent {
 
     pub fn rand() -> Self {
         BallComponent::new(
-            Vector2::new(
+            Vec2::new(
                 -10.0 + rand::random::<f32>() * 20.0,
                 -10.0 + rand::random::<f32>() * 20.0,
             ),
-            Vector2::new(
+            Vec2::new(
                 -1.0 + rand::random::<f32>() * 2.0,
                 -1.0 + rand::random::<f32>() * 2.0,
             ),
@@ -52,13 +52,13 @@ impl BallComponent {
 
         // update rotation
         let curr_rotation = self.transform.rotation();
-        let up = Vector3::new(0.0, 1.0, 0.0);
+        let up = Vec3::new(0.0, 1.0, 0.0);
         let axis_of_rotation = self.direction.cross(up);
         let circumference = 2.0 * std::f32::consts::PI * self.radius;
         let angle_of_rotation =
-            1.0 * (displacement.magnitude() / circumference) * 2.0 * std::f32::consts::PI;
+            1.0 * (displacement.length() / circumference) * 2.0 * std::f32::consts::PI;
         let rotational_displacement =
-            make_quat_from_axis_angle(axis_of_rotation, Rad(-angle_of_rotation));
+            make_quat_from_axis_angle(axis_of_rotation, -angle_of_rotation);
         let new_rotation = rotational_displacement * curr_rotation;
         self.transform.set_rotation(new_rotation);
 
@@ -72,19 +72,19 @@ impl BallComponent {
         // ));
 
         // do collision
-        let pos_2d = Vector2::new(new_position.x, new_position.z);
+        let pos_2d = Vec2::new(new_position.x, new_position.z);
         let ball_edges: Vec<_> = vec![
-            Vector2::new(self.radius, 0.0),
-            Vector2::new(0.0, self.radius),
-            Vector2::new(-self.radius, 0.0),
-            Vector2::new(0.0, -self.radius),
+            Vec2::new(self.radius, 0.0),
+            Vec2::new(0.0, self.radius),
+            Vec2::new(-self.radius, 0.0),
+            Vec2::new(0.0, -self.radius),
         ]
         .iter()
         .map(|pos| *pos + pos_2d)
         .collect();
 
         ball_edges.iter().for_each(|edge| {
-            let Vector2 { x, y: z } = edge;
+            let Vec2 { x, y: z } = edge;
             if *x > ARENA_SIDE_LENGTH || *x < -ARENA_SIDE_LENGTH {
                 // reflect on x
                 self.direction.x = -self.direction.x;
@@ -111,7 +111,7 @@ impl BallComponent {
             .rotation(
                 self.transform
                     .rotation()
-                    .nlerp(other.transform.rotation(), alpha),
+                    .lerp(other.transform.rotation(), alpha),
             )
             .build();
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,11 +1,14 @@
 use super::*;
-use cgmath::{Deg, Euler, Matrix4, Quaternion, Rad, Vector3};
+use glam::{
+    f32::{Mat4, Quat, Vec3},
+    EulerRot,
+};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Camera {
-    pub horizontal_rotation: Rad<f32>,
-    pub vertical_rotation: Rad<f32>,
-    pub position: Vector3<f32>,
+    pub horizontal_rotation: f32,
+    pub vertical_rotation: f32,
+    pub position: Vec3,
 }
 
 impl Camera {
@@ -13,8 +16,8 @@ impl Camera {
         TransformBuilder::new()
             .position(self.position)
             .rotation(
-                Quaternion::from(Euler::new(Rad(0.0), self.horizontal_rotation, Rad(0.0)))
-                    * Quaternion::from(Euler::new(self.vertical_rotation, Rad(0.0), Rad(0.0))),
+                Quat::from_euler(EulerRot::XYZ, 0.0, self.horizontal_rotation, 0.0)
+                    * Quat::from_euler(EulerRot::XYZ, self.vertical_rotation, 0.0, 0.0),
             )
             .build()
     }
@@ -22,10 +25,10 @@ impl Camera {
 
 #[derive(Copy, Clone, Debug)]
 pub struct ShaderCameraView {
-    pub proj: Matrix4<f32>,
-    pub view: Matrix4<f32>,
-    pub rotation_only_view: Matrix4<f32>,
-    pub position: Vector3<f32>,
+    pub proj: Mat4,
+    pub view: Mat4,
+    pub rotation_only_view: Mat4,
+    pub position: Vec3,
     pub near_plane_distance: f32,
     pub far_plane_distance: f32,
 }
@@ -45,9 +48,9 @@ pub struct CameraUniform {
 impl CameraUniform {
     pub fn new() -> Self {
         Self {
-            proj: Matrix4::one().into(),
-            view: Matrix4::one().into(),
-            rotation_only_view: Matrix4::one().into(),
+            proj: Mat4::IDENTITY.to_cols_array_2d(),
+            view: Mat4::IDENTITY.to_cols_array_2d(),
+            rotation_only_view: Mat4::IDENTITY.to_cols_array_2d(),
             position: [0.0; 4],
             near_plane_distance: 0.0,
             far_plane_distance: 0.0,
@@ -58,11 +61,11 @@ impl CameraUniform {
 
 impl ShaderCameraView {
     pub fn from_transform(
-        transform: Matrix4<f32>,
+        transform: Mat4,
         aspect_ratio: f32,
         near_plane_distance: f32,
         far_plane_distance: f32,
-        fov_y: Rad<f32>,
+        fov_y: f32,
         reverse_z: bool,
     ) -> Self {
         let proj = make_perspective_proj_matrix(
@@ -73,8 +76,8 @@ impl ShaderCameraView {
             reverse_z,
         );
         let rotation_only_matrix = clear_translation_from_matrix(transform);
-        let rotation_only_view = rotation_only_matrix.inverse_transform().unwrap();
-        let view = transform.inverse_transform().unwrap();
+        let rotation_only_view = rotation_only_matrix.inverse();
+        let view = transform.inverse();
         let position = get_translation_from_matrix(transform);
         Self {
             proj,
@@ -86,7 +89,7 @@ impl ShaderCameraView {
         }
         // orthographic instead of perspective:
         // build_directional_light_camera_view(
-        //     Vector3::new(-0.5, -0.5, 0.1).normalize(),
+        //     Vec3::new(-0.5, -0.5, 0.1).normalize(),
         //     100.0,
         //     100.0,
         //     100.0,
@@ -107,9 +110,9 @@ impl From<ShaderCameraView> for CameraUniform {
         }: ShaderCameraView,
     ) -> CameraUniform {
         Self {
-            proj: proj.into(),
-            view: view.into(),
-            rotation_only_view: rotation_only_view.into(),
+            proj: proj.to_cols_array_2d(),
+            view: view.to_cols_array_2d(),
+            rotation_only_view: rotation_only_view.to_cols_array_2d(),
             position: [position.x, position.y, position.z, 1.0],
             near_plane_distance,
             far_plane_distance,
@@ -119,24 +122,24 @@ impl From<ShaderCameraView> for CameraUniform {
 }
 
 pub fn build_cubemap_face_camera_views(
-    position: Vector3<f32>,
+    position: Vec3,
     near_plane_distance: f32,
     far_plane_distance: f32,
     reverse_z: bool,
 ) -> Vec<ShaderCameraView> {
     vec![
-        (Deg(90.0), Deg(0.0)),    // right
-        (Deg(-90.0), Deg(0.0)),   // left
-        (Deg(180.0), Deg(90.0)),  // top
-        (Deg(180.0), Deg(-90.0)), // bottom
-        (Deg(180.0), Deg(0.0)),   // front
-        (Deg(0.0), Deg(0.0)),     // back
+        (90.0, 0.0),    // right
+        (-90.0, 0.0),   // left
+        (180.0, 90.0),  // top
+        (180.0, -90.0), // bottom
+        (180.0, 0.0),   // front
+        (0.0, 0.0),     // back
     ]
     .iter()
     .map(
-        |(horizontal_rotation, vertical_rotation): &(Deg<f32>, Deg<f32>)| Camera {
-            horizontal_rotation: (*horizontal_rotation).into(),
-            vertical_rotation: (*vertical_rotation).into(),
+        |(horizontal_rotation, vertical_rotation): &(f32, f32)| Camera {
+            horizontal_rotation: deg_to_rad(*horizontal_rotation),
+            vertical_rotation: deg_to_rad(*vertical_rotation),
             position,
         },
     )
@@ -146,7 +149,7 @@ pub fn build_cubemap_face_camera_views(
             1.0,
             near_plane_distance,
             far_plane_distance,
-            Deg(90.0).into(),
+            deg_to_rad(90.0),
             reverse_z,
         )
     })
@@ -154,21 +157,19 @@ pub fn build_cubemap_face_camera_views(
 }
 
 pub fn build_directional_light_camera_view(
-    direction: Vector3<f32>,
+    direction: Vec3,
     width: f32,
     height: f32,
     depth: f32,
 ) -> ShaderCameraView {
     let proj = make_orthographic_proj_matrix(width, height, -depth / 2.0, depth / 2.0, false);
-    let rotation_only_view = direction_vector_to_coordinate_frame_matrix(direction)
-        .inverse_transform()
-        .unwrap();
+    let rotation_only_view = direction_vector_to_coordinate_frame_matrix(direction).inverse();
     let view = rotation_only_view;
     ShaderCameraView {
         proj,
         view,
         rotation_only_view,
-        position: Vector3::new(0.0, 0.0, 0.0),
+        position: Vec3::new(0.0, 0.0, 0.0),
         near_plane_distance: -depth / 2.0,
         far_plane_distance: depth / 2.0,
     }
@@ -176,20 +177,19 @@ pub fn build_directional_light_camera_view(
 
 #[cfg(test)]
 mod tests {
-    use cgmath::Vector4;
+    use glam::f32::Vec4;
 
     use super::*;
 
     #[test]
     fn should_i_exist() {
         let reverse_z_mat =
-            make_perspective_proj_matrix(0.1, 100000.0, cgmath::Deg(90.0).into(), 1.0, true);
-        let reg_z_mat =
-            make_perspective_proj_matrix(0.1, 100000.0, cgmath::Deg(90.0).into(), 1.0, false);
-        let pos = Vector4::new(-0.5, -0.5, -0.11, 1.0);
+            make_perspective_proj_matrix(0.1, 100000.0, deg_to_rad(90.0), 1.0, true);
+        let reg_z_mat = make_perspective_proj_matrix(0.1, 100000.0, deg_to_rad(90.0), 1.0, false);
+        let pos = Vec4::new(-0.5, -0.5, -0.11, 1.0);
         let reverse_proj_pos = reverse_z_mat * pos;
         let reg_proj_pos = reg_z_mat * pos;
-        let persp_div = |yo: Vector4<f32>| yo / yo.w;
+        let persp_div = |yo: Vec4| yo / yo.w;
         println!("{:?}", reverse_z_mat);
         println!("{:?}", reg_z_mat);
         println!("{:?}", reverse_proj_pos);

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,4 +1,4 @@
-use cgmath::Vector3;
+use glam::f32::Vec3;
 
 use super::*;
 
@@ -101,10 +101,10 @@ impl Character {
                             transform_decomposed.position.z,
                         ),
                         nalgebra::UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
-                            transform_decomposed.rotation.s,
-                            transform_decomposed.rotation.v.x,
-                            transform_decomposed.rotation.v.y,
-                            transform_decomposed.rotation.v.z,
+                            transform_decomposed.rotation.w,
+                            transform_decomposed.rotation.x,
+                            transform_decomposed.rotation.y,
+                            transform_decomposed.rotation.z,
                         )),
                     ))
                 }
@@ -134,7 +134,7 @@ impl Character {
                         })
                         .unwrap_or_else(|| vec![self.collision_debug_mesh_index]),
                     mesh_type: GameNodeMeshType::Unlit {
-                        color: Vector3::new(1.0, 0.0, 0.0),
+                        color: Vec3::new(1.0, 0.0, 0.0),
                     },
                     wireframe: true,
                     ..Default::default()
@@ -161,7 +161,7 @@ impl Character {
                         })
                         .unwrap_or_else(|| vec![self.collision_debug_mesh_index]),
                     mesh_type: GameNodeMeshType::Unlit {
-                        color: Vector3::new(rand::random(), rand::random(), rand::random()),
+                        color: Vec3::new(rand::random(), rand::random(), rand::random()),
                     },
                     wireframe: true,
                     ..Default::default()

--- a/src/collisions.rs
+++ b/src/collisions.rs
@@ -1,7 +1,5 @@
 use glam::f32::Vec3;
 
-use super::*;
-
 #[derive(Debug, Clone, Copy)]
 pub struct Aabb {
     pub min: Vec3,

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use anyhow::Result;
-use cgmath::{Deg, Rad, Vector3, Vector4};
+use glam::f32::{Vec3, Vec4};
 use rapier3d::prelude::*;
 use winit::event::{ElementState, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 
@@ -10,15 +10,15 @@ pub const INITIAL_TONE_MAPPING_EXPOSURE: f32 = 0.3;
 pub const INITIAL_BLOOM_THRESHOLD: f32 = 0.8;
 pub const INITIAL_BLOOM_RAMP_SIZE: f32 = 0.2;
 pub const ARENA_SIDE_LENGTH: f32 = 500.0;
-// pub const LIGHT_COLOR_A: Vector3<f32> = Vector3::new(0.996, 0.973, 0.663);
-// pub const LIGHT_COLOR_B: Vector3<f32> = Vector3::new(0.25, 0.973, 0.663);
+// pub const LIGHT_COLOR_A: Vec3 = Vec3::new(0.996, 0.973, 0.663);
+// pub const LIGHT_COLOR_B: Vec3 = Vec3::new(0.25, 0.973, 0.663);
 
 // linear colors, not srgb
-pub const DIRECTIONAL_LIGHT_COLOR_A: Vector3<f32> = Vector3::new(0.84922975, 0.81581426, 0.8832506);
-pub const DIRECTIONAL_LIGHT_COLOR_B: Vector3<f32> = Vector3::new(0.81115574, 0.77142686, 0.8088144);
-pub const POINT_LIGHT_COLOR: Vector3<f32> = Vector3::new(0.93126976, 0.7402633, 0.49407062);
-// pub const LIGHT_COLOR_C: Vector3<f32> =
-//     Vector3::new(from_srgb(0.631), from_srgb(0.565), from_srgb(0.627));
+pub const DIRECTIONAL_LIGHT_COLOR_A: Vec3 = Vec3::new(0.84922975, 0.81581426, 0.8832506);
+pub const DIRECTIONAL_LIGHT_COLOR_B: Vec3 = Vec3::new(0.81115574, 0.77142686, 0.8088144);
+pub const POINT_LIGHT_COLOR: Vec3 = Vec3::new(0.93126976, 0.7402633, 0.49407062);
+// pub const LIGHT_COLOR_C: Vec3 =
+//     Vec3::new(from_srgb(0.631), from_srgb(0.565), from_srgb(0.627));
 
 pub const COLLISION_GROUP_PLAYER_UNSHOOTABLE: Group = Group::GROUP_1;
 
@@ -81,10 +81,10 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
     let player_controller = PlayerController::new(
         &mut physics_state,
         6.0,
-        Vector3::new(8.0, 30.0, -13.0),
+        Vec3::new(8.0, 30.0, -13.0),
         ControlledViewDirection {
-            horizontal: Deg(180.0).into(),
-            vertical: Rad(0.0),
+            horizontal: deg_to_rad(180.0),
+            vertical: 0.0,
         },
     );
 
@@ -111,21 +111,21 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
             animation_index,
             // revolver model
             // TransformBuilder::new()
-            //     .position(Vector3::new(0.21, -0.09, -1.0))
+            //     .position(Vec3::new(0.21, -0.09, -1.0))
             //     .rotation(make_quat_from_axis_angle(
-            //         Vector3::new(0.0, 1.0, 0.0),
-            //         Deg(180.0).into(),
+            //         Vec3::new(0.0, 1.0, 0.0),
+            //         deg_to_rad(180.0).into(),
             //     ))
-            //     .scale(0.17f32 * Vector3::new(1.0, 1.0, 1.0))
+            //     .scale(0.17f32 * Vec3::new(1.0, 1.0, 1.0))
             //     .build(),
             // colt python model
             TransformBuilder::new()
-                .position(Vector3::new(0.21, -0.13, -1.0))
+                .position(Vec3::new(0.21, -0.13, -1.0))
                 .rotation(
-                    make_quat_from_axis_angle(Vector3::new(0.0, 1.0, 0.0), Deg(180.0).into())
-                        * make_quat_from_axis_angle(Vector3::new(0.0, 1.0, 0.0), Rad(0.1)),
+                    make_quat_from_axis_angle(Vec3::new(0.0, 1.0, 0.0), deg_to_rad(180.0))
+                        * make_quat_from_axis_angle(Vec3::new(0.0, 1.0, 0.0), 0.1),
                 )
-                .scale(2.0f32 * Vector3::new(1.0, 1.0, 1.0))
+                .scale(2.0f32 * Vec3::new(1.0, 1.0, 1.0))
                 .build(),
         ));
     }
@@ -146,7 +146,7 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
                 continue;
             }
             node.transform
-                .set_position(node.transform.position() + Vector3::new(0.0, 29.0, 0.0));
+                .set_position(node.transform.position() + Vec3::new(0.0, 29.0, 0.0));
         }
         scene.merge_scene(renderer_state, other_scene, other_render_buffers);
     }
@@ -239,39 +239,39 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
     // add lights to the scene
     let directional_lights = vec![
         DirectionalLightComponent {
-            position: Vector3::new(1.0, 5.0, -10.0) * 10.0,
-            direction: (-Vector3::new(1.0, 5.0, -10.0)).normalize(),
+            position: Vec3::new(1.0, 5.0, -10.0) * 10.0,
+            direction: (-Vec3::new(1.0, 5.0, -10.0)).normalize(),
             color: DIRECTIONAL_LIGHT_COLOR_A,
             intensity: 1.0,
         },
         DirectionalLightComponent {
-            position: Vector3::new(-1.0, 10.0, 10.0) * 10.0,
-            direction: (-Vector3::new(-1.0, 10.0, 10.0)).normalize(),
+            position: Vec3::new(-1.0, 10.0, 10.0) * 10.0,
+            direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
             color: DIRECTIONAL_LIGHT_COLOR_B,
             intensity: 1.0,
         },
     ];
     // let directional_lights: Vec<DirectionalLightComponent> = vec![];
 
-    let point_lights: Vec<(transform::Transform, Vector3<f32>, f32)> = vec![
+    let point_lights: Vec<(transform::Transform, Vec3, f32)> = vec![
         (
             TransformBuilder::new()
-                .scale(Vector3::new(0.05, 0.05, 0.05))
-                .position(Vector3::new(0.0, 12.0, 0.0))
+                .scale(Vec3::new(0.05, 0.05, 0.05))
+                .position(Vec3::new(0.0, 12.0, 0.0))
                 .build(),
             POINT_LIGHT_COLOR,
             1.0,
         ),
         // (
         //     TransformBuilder::new()
-        //         .scale(Vector3::new(0.1, 0.1, 0.1))
-        //         .position(Vector3::new(0.0, 15.0, 0.0))
+        //         .scale(Vec3::new(0.1, 0.1, 0.1))
+        //         .position(Vec3::new(0.0, 15.0, 0.0))
         //         .build(),
         //     LIGHT_COLOR_B,
         //     1.0,
         // ),
     ];
-    // let point_lights: Vec<(transform::Transform, Vector3<f32>, f32)> = vec![];
+    // let point_lights: Vec<(transform::Transform, Vec3, f32)> = vec![];
 
     let point_light_unlit_mesh_index = renderer_state.bind_basic_unlit_mesh(&sphere_mesh);
     let mut point_light_node_ids: Vec<GameNodeId> = Vec::new();
@@ -377,8 +377,8 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
                 )))
                 .transform(
                     TransformBuilder::new()
-                        .position(Vector3::new(4.0, 10.0, 4.0))
-                        // .scale(Vector3::new(0.0, 0.0, 0.0))
+                        .position(Vec3::new(4.0, 10.0, 4.0))
+                        // .scale(Vec3::new(0.0, 0.0, 0.0))
                         .build(),
                 )
                 .build(),
@@ -396,7 +396,7 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
             .get_node_mut(legendary_robot_root_node_id)
             .unwrap()
             .transform
-            .set_position(Vector3::new(2.0, 0.0, 0.0));
+            .set_position(Vec3::new(2.0, 0.0, 0.0));
 
         let legendary_robot_skin_index = 0;
         Character::new(
@@ -546,8 +546,8 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
     //         }))
     //         .transform(
     //             TransformBuilder::new()
-    //                 .scale(Vector3::new(0.5, 0.5, 0.5))
-    //                 .position(Vector3::new(0.0, 0.5, 0.0))
+    //                 .scale(Vec3::new(0.5, 0.5, 0.5))
+    //                 .position(Vec3::new(0.0, 0.5, 0.0))
     //                 .build(),
     //         )
     //         .build(),
@@ -563,7 +563,7 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
         Default::default(),
     )?;
     let floor_transform = TransformBuilder::new()
-        .scale(Vector3::new(ARENA_SIDE_LENGTH, 1.0, ARENA_SIDE_LENGTH))
+        .scale(Vec3::new(ARENA_SIDE_LENGTH, 1.0, ARENA_SIDE_LENGTH))
         .build();
     let _floor_node = scene.add_node(
         GameNodeDescBuilder::new()
@@ -610,12 +610,12 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
                 )))
                 .transform(
                     TransformBuilder::new()
-                        .scale(Vector3::new(
+                        .scale(Vec3::new(
                             bouncing_ball_radius,
                             bouncing_ball_radius,
                             bouncing_ball_radius,
                         ))
-                        .position(Vector3::new(-1.0, 10.0, 0.0))
+                        .position(Vec3::new(-1.0, 10.0, 0.0))
                         .build(),
                 )
                 .build(),
@@ -727,7 +727,7 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
         },
         Default::default(),
     )?;
-    let crosshair_color = Vector3::new(1.0, 0.0, 0.0);
+    let crosshair_color = Vec3::new(1.0, 0.0, 0.0);
     crosshair_node_id = Some(
         scene
             .add_node(
@@ -737,7 +737,7 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
                         mesh_type: GameNodeMeshType::Pbr {
                             material_override: Some(DynamicPbrParams {
                                 emissive_factor: crosshair_color,
-                                base_color_factor: Vector4::new(0.0, 0.0, 0.0, 1.0),
+                                base_color_factor: Vec4::new(0.0, 0.0, 0.0, 1.0),
                                 alpha_cutoff: 0.5,
                                 ..Default::default()
                             }),
@@ -990,7 +990,7 @@ pub fn update_game_state(game_state: &mut GameState, renderer_state: &RendererSt
         //     (global_time_seconds * 2.0).sin(),
         // );
         if let Some(node) = game_state.scene.get_node_mut(point_light_0.node_id) {
-            node.transform.set_position(Vector3::new(
+            node.transform.set_position(Vec3::new(
                 1.5 * (global_time_seconds * 0.25 + std::f32::consts::PI).cos(),
                 node.transform.position().y - frame_time_seconds * 0.25,
                 1.5 * (global_time_seconds * 0.25 + std::f32::consts::PI).sin(),
@@ -1029,7 +1029,7 @@ pub fn update_game_state(game_state: &mut GameState, renderer_state: &RendererSt
         .get(0)
         .map(|directional_light_0| {
             let direction = directional_light_0.direction;
-            // transform.set_position(Vector3::new(
+            // transform.set_position(Vec3::new(
             //     1.1 * (time_seconds * 0.25 + std::f32::consts::PI).cos(),
             //     transform.position.get().y,
             //     1.1 * (time_seconds * 0.25 + std::f32::consts::PI).sin(),
@@ -1037,7 +1037,7 @@ pub fn update_game_state(game_state: &mut GameState, renderer_state: &RendererSt
             // let color = lerp_vec(LIGHT_COLOR_B, LIGHT_COLOR_A, (time_seconds * 2.0).sin());
 
             DirectionalLightComponent {
-                direction: Vector3::new(direction.x, direction.y + 0.0001, direction.z),
+                direction: Vec3::new(direction.x, direction.y + 0.0001, direction.z),
                 ..*directional_light_0
             }
         });
@@ -1047,7 +1047,7 @@ pub fn update_game_state(game_state: &mut GameState, renderer_state: &RendererSt
 
     // rotate the test object
     let rotational_displacement =
-        make_quat_from_axis_angle(Vector3::new(0.0, 1.0, 0.0), Rad(frame_time_seconds / 5.0));
+        make_quat_from_axis_angle(Vec3::new(0.0, 1.0, 0.0), frame_time_seconds / 5.0);
     if let Some(node) = game_state
         .scene
         .get_node_mut(game_state.test_object_node_id)
@@ -1121,15 +1121,15 @@ pub fn update_game_state(game_state: &mut GameState, renderer_state: &RendererSt
     {
         crosshair_node.transform = new_player_transform
             * TransformBuilder::new()
-                .position(Vector3::new(0.0, 0.0, -1.0))
+                .position(Vec3::new(0.0, 0.0, -1.0))
                 .rotation(make_quat_from_axis_angle(
-                    Vector3::new(0.0, 1.0, 0.0),
-                    Deg(90.0).into(),
+                    Vec3::new(0.0, 1.0, 0.0),
+                    deg_to_rad(90.0),
                 ))
                 .scale(
                     (1080.0 / renderer_state.base.window_size.height as f32)
                         * 0.06
-                        * Vector3::new(1.0, 1.0, 1.0),
+                        * Vec3::new(1.0, 1.0, 1.0),
                 )
                 .build();
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -139,7 +139,7 @@ pub fn init_game_state(mut scene: Scene, renderer_state: &mut RendererState) -> 
         // hack to get the terrain to be at the same height as the ground.
         let node_has_parent: Vec<_> = other_scene
             .nodes()
-            .map(|node| other_scene.get_node_parent(node.id()).is_some())
+            .map(|node| node.parent_id.is_some())
             .collect();
         for (i, node) in other_scene.nodes_mut().enumerate() {
             if node_has_parent[i] {

--- a/src/gltf_loader.rs
+++ b/src/gltf_loader.rs
@@ -180,7 +180,7 @@ pub fn build_scene(
     // for any of the other stuff that refers to the nodes by index such as the animations
     let nodes: Vec<_> = document
         .nodes()
-        .map(|node| GameNodeDesc {
+        .map(|node| IndexedGameNodeDesc {
             transform: crate::transform::Transform::from(node.transform()),
             skin_index: node.skin().map(|skin| skin.index()),
             mesh: node_mesh_links
@@ -193,6 +193,7 @@ pub fn build_scene(
                     ..Default::default()
                 }),
             name: node.name().map(|name| name.to_string()),
+            parent_index: parent_index_map.get(&node.index()).copied(),
         })
         .collect();
 
@@ -326,7 +327,7 @@ pub fn build_scene(
         render_buffers.textures.len()
     ));
 
-    let scene = Scene::new(nodes, skins, animations, parent_index_map);
+    let scene = Scene::new(nodes, skins, animations);
 
     Ok((scene, render_buffers))
 }

--- a/src/light.rs
+++ b/src/light.rs
@@ -1,18 +1,18 @@
 use super::*;
 
-use cgmath::Vector3;
+use glam::f32::Vec3;
 
 #[derive(Clone, Debug)]
 pub struct PointLightComponent {
     pub node_id: GameNodeId,
-    pub color: Vector3<f32>,
+    pub color: Vec3,
     pub intensity: f32,
 }
 
 #[derive(Clone, Debug)]
 pub struct DirectionalLightComponent {
-    pub position: Vector3<f32>,
-    pub direction: Vector3<f32>,
-    pub color: Vector3<f32>,
+    pub position: Vec3,
+    pub direction: Vec3,
+    pub color: Vec3,
     pub intensity: f32,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,6 @@ use audio::*;
 use ball::*;
 use buffer::*;
 use camera::*;
-use cgmath::prelude::*;
 use character::*;
 use collisions::*;
 use default_textures::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ async fn start() {
         } else {
             wgpu::Backends::all()
         };
-        BaseRendererState::new(&window, backends, wgpu::PresentMode::AutoVsync).await
+        BaseRendererState::new(&window, backends, wgpu::PresentMode::AutoNoVsync).await
     };
 
     let run_result = async {

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,4 +1,4 @@
-use cgmath::Vector3;
+use glam::f32::Vec3;
 
 pub fn _to_srgb(val: f32) -> f32 {
     val.powf(2.2)
@@ -12,6 +12,10 @@ pub fn lerp(from: f32, to: f32, alpha: f32) -> f32 {
     (alpha * to) + ((1.0 - alpha) * from)
 }
 
-pub fn lerp_vec(a: Vector3<f32>, b: Vector3<f32>, alpha: f32) -> Vector3<f32> {
+pub fn lerp_vec(a: Vec3, b: Vec3, alpha: f32) -> Vec3 {
     b * alpha + a * (1.0 - alpha)
+}
+
+pub fn deg_to_rad(deg: f32) -> f32 {
+    deg * std::f32::consts::PI / 180.0
 }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cgmath::{Vector3, Vector4};
+use glam::f32::{Vec3, Vec4};
 use rapier3d::prelude::*;
 
 use super::*;
@@ -94,17 +94,17 @@ impl PhysicsState {
                     };
                     let base_scale = (bounding_box.max - bounding_box.min) / 2.0;
                     let base_position = (bounding_box.max + bounding_box.min) / 2.0;
-                    let scale = Vector3::new(
+                    let scale = Vec3::new(
                         base_scale.x * transform_decomposed.scale.x,
                         base_scale.y * transform_decomposed.scale.y,
                         base_scale.z * transform_decomposed.scale.z,
                     );
                     let position_rotated = {
                         let rotated = make_rotation_matrix(transform_decomposed.rotation)
-                            * Vector4::new(base_position.x, base_position.y, base_position.z, 1.0);
-                        Vector3::new(rotated.x, rotated.y, rotated.z)
+                            * Vec4::new(base_position.x, base_position.y, base_position.z, 1.0);
+                        Vec3::new(rotated.x, rotated.y, rotated.z)
                     };
-                    let position = Vector3::new(
+                    let position = Vec3::new(
                         position_rotated.x + transform_decomposed.position.x,
                         position_rotated.y + transform_decomposed.position.y,
                         position_rotated.z + transform_decomposed.position.z,
@@ -121,10 +121,7 @@ impl PhysicsState {
                     collider.set_position(Isometry::from_parts(
                         nalgebra::Translation3::new(position.x, position.y, position.z),
                         nalgebra::UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
-                            rotation.s,
-                            rotation.v.x,
-                            rotation.v.y,
-                            rotation.v.z,
+                            rotation.w, rotation.x, rotation.y, rotation.z,
                         )),
                     ));
                     collider_handles.push(self.collider_set.insert(collider));

--- a/src/physics_ball.rs
+++ b/src/physics_ball.rs
@@ -1,4 +1,4 @@
-use cgmath::Vector3;
+use glam::f32::Vec3;
 
 use super::*;
 
@@ -15,12 +15,12 @@ impl PhysicsBall {
         scene: &mut Scene,
         physics_state: &mut PhysicsState,
         mesh: GameNodeMesh,
-        position: Vector3<f32>,
+        position: Vec3,
         radius: f32,
     ) -> Self {
         let transform = TransformBuilder::new()
-            .position(Vector3::new(position.x, position.y, position.z))
-            .scale(Vector3::new(radius, radius, radius))
+            .position(Vec3::new(position.x, position.y, position.z))
+            .scale(Vec3::new(radius, radius, radius))
             .build();
 
         let node = scene.add_node(
@@ -62,7 +62,7 @@ impl PhysicsBall {
         mesh: GameNodeMesh,
     ) -> Self {
         let radius = 0.2 + (rand::random::<f32>() * 0.4);
-        let position = Vector3::new(
+        let position = Vec3::new(
             ARENA_SIDE_LENGTH * (rand::random::<f32>() * 2.0 - 1.0) / 4.0,
             radius * 2.0 + rand::random::<f32>() * 15.0 + 5.0,
             ARENA_SIDE_LENGTH * (rand::random::<f32>() * 2.0 - 1.0) / 4.0,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -2386,7 +2386,7 @@ impl RendererState {
             }
         }
 
-        scene.recompute_node_transforms();
+        // scene.recompute_node_transforms();
         scene.recompute_global_node_transforms();
     }
 
@@ -2395,7 +2395,7 @@ impl RendererState {
     pub fn update(&mut self, game_state: &mut GameState) {
         self.clear_debug_nodes(&mut game_state.scene);
 
-        game_state.scene.recompute_node_transforms();
+        // game_state.scene.recompute_node_transforms();
         game_state.scene.recompute_global_node_transforms();
 
         let camera_frustum = game_state.player_controller.frustum(

--- a/src/revolver.rs
+++ b/src/revolver.rs
@@ -33,12 +33,20 @@ impl Revolver {
         animation_index: usize,
         transform: crate::transform::Transform,
     ) -> Self {
-        let node_id = scene
-            .add_node(GameNodeDescBuilder::new().transform(transform).build())
-            .id();
-        let hand_node_id = scene.add_node(GameNodeDescBuilder::new().build()).id();
-        scene.set_node_parent(node_id, hand_node_id);
-        scene.set_node_parent(model_node_id, node_id);
+        let hand_node = scene.add_node(GameNodeDescBuilder::new().build());
+        let hand_node_id = hand_node.id();
+
+        let node = scene.add_node(
+            GameNodeDescBuilder::new()
+                .transform(transform)
+                .parent_id(Some(hand_node_id))
+                .build(),
+        );
+        let node_id = node.id();
+
+        if let Some(model_node) = scene.get_node_mut(model_node_id) {
+            model_node.parent_id = Some(node_id);
+        }
 
         // let cooldown = scene.animations[animation_index].length_seconds;
         let cooldown = scene.animations[animation_index].length_seconds + 0.1;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -421,11 +421,14 @@ impl Scene {
             node_ancestry_list[i] = node_index;
             ancestry_length += 1;
         }
-        let mut acc: Mat4 = Mat4::IDENTITY;
-        for ancestry_list_index in (0..ancestry_length).rev() {
+        let mut ancestry_transforms = (0..ancestry_length).rev().map(|ancestry_list_index| {
             let node_index = node_ancestry_list[ancestry_list_index];
             let (node, _) = &self.nodes[node_index as usize];
-            acc = acc * node.as_ref().unwrap().transform.matrix();
+            node.as_ref().unwrap().transform.matrix()
+        });
+        let mut acc: Mat4 = ancestry_transforms.next().unwrap();
+        for ancestry_transform in ancestry_transforms {
+            acc *= ancestry_transform
         }
         acc
     }

--- a/src/scene_tree.rs
+++ b/src/scene_tree.rs
@@ -1,4 +1,4 @@
-use cgmath::Vector3;
+use glam::f32::Vec3;
 use smallvec::{smallvec, SmallVec};
 
 use super::*;
@@ -32,8 +32,8 @@ impl Default for SceneTreeNode {
     fn default() -> Self {
         Self {
             base_aabb: Aabb {
-                min: Vector3::zero(),
-                max: Vector3::zero(),
+                min: Vec3::default(),
+                max: Vec3::default(),
             },
             game_nodes: smallvec![],
             children: None,
@@ -74,8 +74,8 @@ impl SceneTree {
         //     tree.node_list.capacity(),
         // ));
 
-        let _offset = ROOT_AABB_SIZE * 0.02 * std::f32::consts::PI * Vector3::new(1.0, 1.0, 1.0);
-        let root_aabb_max = ROOT_AABB_SIZE * Vector3::new(1.0, 1.0, 1.0);
+        let _offset = ROOT_AABB_SIZE * 0.02 * std::f32::consts::PI * Vec3::new(1.0, 1.0, 1.0);
+        let root_aabb_max = ROOT_AABB_SIZE * Vec3::new(1.0, 1.0, 1.0);
         let root = SceneTreeNode {
             base_aabb: Aabb {
                 min: -root_aabb_max, /*  + _offset */
@@ -129,7 +129,8 @@ impl SceneTree {
             if node_bounding_sphere.radius < child_base_aabb.size().x / 2.0
                 || child_aabb.fully_contains_sphere(node_bounding_sphere)
             {
-                let distance2 = (child_aabb.origin() - node_bounding_sphere.origin).magnitude2();
+                let distance2 =
+                    (child_aabb.origin() - node_bounding_sphere.origin).length_squared();
                 // pick the aabb whose origin is closest to the object
                 fully_contained_index = match fully_contained_index {
                     Some((other_i, other_dist2)) => Some(if distance2 < other_dist2 {
@@ -297,7 +298,7 @@ impl SceneTreeNode {
         // aabb must be a cube!
         let extension_factor = (aabb.max.x - aabb.min.x) * K_FACTOR;
         let extension_factor_vector =
-            Vector3::new(extension_factor, extension_factor, extension_factor);
+            Vec3::new(extension_factor, extension_factor, extension_factor);
         Aabb {
             min: aabb.min - extension_factor_vector,
             max: aabb.max + extension_factor_vector,

--- a/src/skinning.rs
+++ b/src/skinning.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use cgmath::Matrix4;
+use glam::f32::Mat4;
 
 use super::*;
 
@@ -21,13 +21,13 @@ pub fn get_all_bone_data(
     scene: &Scene,
     min_storage_buffer_offset_alignment: u32,
 ) -> AllBoneTransforms {
-    let matrix_size_bytes = std::mem::size_of::<GpuMatrix4>();
+    let matrix_size_bytes = std::mem::size_of::<Mat4>();
     let identity_bone_count = 4;
     let identity_slice = (0, identity_bone_count * matrix_size_bytes);
 
     let mut buffer: Vec<u8> = bytemuck::cast_slice(
         &((0..identity_bone_count)
-            .map(|_| GpuMatrix4(Matrix4::one()))
+            .map(|_| Mat4::IDENTITY)
             .collect::<Vec<_>>()),
     )
     .to_vec();
@@ -63,13 +63,13 @@ pub fn get_all_bone_data(
                             .iter()
                             .enumerate()
                             .map(|(bone_index, bone_node_id)| {
-                                GpuMatrix4(get_bone_skeleton_space_transform(
+                                get_bone_skeleton_space_transform(
                                     scene,
                                     skin,
                                     skin.node_id,
                                     bone_index,
                                     *bone_node_id,
-                                ))
+                                )
                             })
                             .collect();
 
@@ -108,7 +108,7 @@ pub fn get_bone_skeleton_space_transform(
     skeleton_skin_node_id: GameNodeId,
     bone_index: usize,
     bone_node_id: GameNodeId,
-) -> Matrix4<f32> {
+) -> Mat4 {
     let node_ancestry_list =
         scene.get_skeleton_node_ancestry_list(bone_node_id, skeleton_skin_node_id);
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::{num::NonZeroU32, ops::Deref};
 
 use anyhow::*;
-use cgmath::Vector3;
+use glam::f32::Vec3;
 use wgpu::util::DeviceExt;
 
 #[derive(Debug)]
@@ -489,7 +489,7 @@ impl Texture {
         });
 
         let faces: Vec<_> = build_cubemap_face_camera_views(
-            Vector3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 0.0),
             NEAR_PLANE_DISTANCE,
             FAR_PLANE_DISTANCE,
             true,
@@ -750,7 +750,7 @@ impl Texture {
         });
 
         let faces: Vec<_> = build_cubemap_face_camera_views(
-            Vector3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 0.0),
             NEAR_PLANE_DISTANCE,
             FAR_PLANE_DISTANCE,
             true,
@@ -950,7 +950,7 @@ impl Texture {
         });
 
         let camera_projection_matrices = build_cubemap_face_camera_views(
-            Vector3::new(0.0, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, 0.0),
             NEAR_PLANE_DISTANCE,
             FAR_PLANE_DISTANCE,
             true,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,52 +1,52 @@
-use cgmath::{InnerSpace, Matrix, Matrix3, Matrix4, One, Quaternion, Rad, Vector3};
+use glam::f32::{Mat3, Mat4, Quat, Vec3};
 use std::ops::Mul;
 
 use super::*;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct SimpleTransform {
-    pub position: Vector3<f32>,
-    pub rotation: Quaternion<f32>,
-    pub scale: Vector3<f32>,
+    pub position: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Transform {
-    position: Vector3<f32>,
-    rotation: Quaternion<f32>,
-    scale: Vector3<f32>,
-    matrix: Matrix4<f32>,
-    base_matrix: Matrix4<f32>,
+    position: Vec3,
+    rotation: Quat,
+    scale: Vec3,
+    matrix: Mat4,
+    base_matrix: Mat4,
     is_new: bool,
 }
 
 impl Transform {
     pub fn new() -> Transform {
         Transform {
-            position: Vector3::new(0.0, 0.0, 0.0),
-            rotation: Quaternion::new(0.0, 0.0, 1.0, 0.0),
-            scale: Vector3::new(1.0, 1.0, 1.0),
-            matrix: Matrix4::one(),
-            base_matrix: Matrix4::one(),
+            position: Vec3::new(0.0, 0.0, 0.0),
+            rotation: Quat::IDENTITY,
+            scale: Vec3::new(1.0, 1.0, 1.0),
+            matrix: Mat4::IDENTITY,
+            base_matrix: Mat4::IDENTITY,
             is_new: true,
         }
     }
 
-    pub fn position(&self) -> Vector3<f32> {
+    pub fn position(&self) -> Vec3 {
         self.position
     }
 
-    pub fn rotation(&self) -> Quaternion<f32> {
+    pub fn rotation(&self) -> Quat {
         self.rotation
     }
 
-    pub fn scale(&self) -> Vector3<f32> {
+    pub fn scale(&self) -> Vec3 {
         self.scale
     }
 
-    pub fn matrix(&self) -> Matrix4<f32> {
+    pub fn matrix(&self) -> Mat4 {
         if self.is_new {
-            Matrix4::identity()
+            Mat4::IDENTITY
         } else {
             self.matrix * self.base_matrix
         }
@@ -56,91 +56,67 @@ impl Transform {
         self.is_new
     }
 
-    pub fn set_position(&mut self, new_position: Vector3<f32>) {
+    pub fn set_position(&mut self, new_position: Vec3) {
         self.position = new_position;
-        self.matrix.w.x = new_position.x;
-        self.matrix.w.y = new_position.y;
-        self.matrix.w.z = new_position.z;
+        self.matrix.w_axis.x = new_position.x;
+        self.matrix.w_axis.y = new_position.y;
+        self.matrix.w_axis.z = new_position.z;
         self.is_new = false;
     }
 
-    pub fn set_rotation(&mut self, new_rotation: Quaternion<f32>) {
+    pub fn set_rotation(&mut self, new_rotation: Quat) {
         self.rotation = new_rotation;
         self.is_new = false;
         self.resync_matrix();
     }
 
-    pub fn set_scale(&mut self, new_scale: Vector3<f32>) {
+    pub fn set_scale(&mut self, new_scale: Vec3) {
         self.scale = new_scale;
         self.is_new = false;
         self.resync_matrix();
     }
 
-    pub fn _get_rotation_matrix(&self) -> Matrix4<f32> {
+    pub fn _get_rotation_matrix(&self) -> Mat4 {
         make_rotation_matrix(self.rotation) * self.base_matrix
     }
 
-    pub fn _get_rotation_matrix3(&self) -> Matrix3<f32> {
+    pub fn _get_rotation_matrix3(&self) -> Mat3 {
         let rotation_matrix = self._get_rotation_matrix();
-        Matrix3::from_cols(
-            Vector3::new(
-                rotation_matrix.x.x,
-                rotation_matrix.x.y,
-                rotation_matrix.x.z,
+        Mat3::from_cols(
+            Vec3::new(
+                rotation_matrix.x_axis.x,
+                rotation_matrix.x_axis.y,
+                rotation_matrix.x_axis.z,
             ),
-            Vector3::new(
-                rotation_matrix.y.x,
-                rotation_matrix.y.y,
-                rotation_matrix.y.z,
+            Vec3::new(
+                rotation_matrix.y_axis.x,
+                rotation_matrix.y_axis.y,
+                rotation_matrix.y_axis.z,
             ),
-            Vector3::new(
-                rotation_matrix.z.x,
-                rotation_matrix.z.y,
-                rotation_matrix.z.z,
+            Vec3::new(
+                rotation_matrix.z_axis.x,
+                rotation_matrix.z_axis.y,
+                rotation_matrix.z_axis.z,
             ),
         )
     }
 
     pub fn apply_isometry(&mut self, isometry: Isometry<f32>) {
-        self.set_position(Vector3::new(
+        self.set_position(Vec3::new(
             isometry.translation.x,
             isometry.translation.y,
             isometry.translation.z,
         ));
-        self.set_rotation(Quaternion::new(
-            isometry.rotation.w,
+        self.set_rotation(Quat::from_xyzw(
             isometry.rotation.i,
             isometry.rotation.j,
             isometry.rotation.k,
+            isometry.rotation.w,
         ));
     }
 
     pub fn decompose(&self) -> SimpleTransform {
-        let mat = self.matrix();
-        let position = Vector3::new(mat.w.x, mat.w.y, mat.w.z);
-        let scale = Vector3::new(
-            Vector3::new(mat.x.x, mat.x.y, mat.x.z).magnitude(),
-            Vector3::new(mat.y.x, mat.y.y, mat.y.z).magnitude(),
-            Vector3::new(mat.z.x, mat.z.y, mat.z.z).magnitude(),
-        );
-        let rotation = get_quat_from_rotation_matrix(Matrix4::new(
-            mat.x.x / scale.x,
-            mat.x.y / scale.x,
-            mat.x.z / scale.x,
-            0.0,
-            mat.y.x / scale.y,
-            mat.y.y / scale.y,
-            mat.y.z / scale.y,
-            0.0,
-            mat.z.x / scale.z,
-            mat.z.y / scale.z,
-            mat.z.z / scale.z,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-        ));
+        let (scale, rotation, position) = self.matrix().to_scale_rotation_translation();
 
         SimpleTransform {
             position,
@@ -156,8 +132,8 @@ impl Transform {
     }
 }
 
-impl From<Matrix4<f32>> for Transform {
-    fn from(matrix: Matrix4<f32>) -> Self {
+impl From<Mat4> for Transform {
+    fn from(matrix: Mat4) -> Self {
         let mut transform = Transform::new();
         transform.base_matrix = matrix;
         transform.is_new = false;
@@ -186,9 +162,9 @@ impl From<gltf::scene::Transform> for Transform {
             } => TransformBuilder::new()
                 .position(translation.into())
                 .scale(scale.into())
-                .rotation(rotation.into())
+                .rotation(Quat::from_array(rotation))
                 .build(),
-            gltf::scene::Transform::Matrix { matrix } => Matrix4::from(matrix).into(),
+            gltf::scene::Transform::Matrix { matrix } => Mat4::from_cols_array_2d(&matrix).into(),
         }
     }
 }
@@ -196,12 +172,12 @@ impl From<gltf::scene::Transform> for Transform {
 impl From<Isometry<f32>> for Transform {
     fn from(isometry: Isometry<f32>) -> Self {
         let mut transform = Transform::new();
-        transform.set_position(Vector3::new(
+        transform.set_position(Vec3::new(
             isometry.translation.x,
             isometry.translation.y,
             isometry.translation.z,
         ));
-        transform.set_rotation(Quaternion::new(
+        transform.set_rotation(Quat::from_xyzw(
             isometry.rotation.i,
             isometry.rotation.j,
             isometry.rotation.k,
@@ -225,38 +201,38 @@ impl Mul for Transform {
 
 #[derive(Clone, Debug)]
 pub struct TransformBuilder {
-    position: Vector3<f32>,
-    rotation: Quaternion<f32>,
-    scale: Vector3<f32>,
-    base_matrix: Matrix4<f32>,
+    position: Vec3,
+    rotation: Quat,
+    scale: Vec3,
+    base_matrix: Mat4,
 }
 
 impl TransformBuilder {
     pub fn new() -> Self {
         Self {
-            position: Vector3::new(0.0, 0.0, 0.0),
-            rotation: Quaternion::new(0.0, 0.0, 1.0, 0.0),
-            scale: Vector3::new(1.0, 1.0, 1.0),
-            base_matrix: Matrix4::one(),
+            position: Vec3::new(0.0, 0.0, 0.0),
+            rotation: Quat::IDENTITY,
+            scale: Vec3::new(1.0, 1.0, 1.0),
+            base_matrix: Mat4::IDENTITY,
         }
     }
 
-    pub fn position(mut self, position: Vector3<f32>) -> Self {
+    pub fn position(mut self, position: Vec3) -> Self {
         self.position = position;
         self
     }
 
-    pub fn rotation(mut self, rotation: Quaternion<f32>) -> Self {
+    pub fn rotation(mut self, rotation: Quat) -> Self {
         self.rotation = rotation;
         self
     }
 
-    pub fn scale(mut self, scale: Vector3<f32>) -> Self {
+    pub fn scale(mut self, scale: Vec3) -> Self {
         self.scale = scale;
         self
     }
 
-    pub fn _base_matrix(mut self, base_matrix: Matrix4<f32>) -> Self {
+    pub fn _base_matrix(mut self, base_matrix: Mat4) -> Self {
         self.base_matrix = base_matrix;
         self
     }
@@ -273,15 +249,15 @@ impl TransformBuilder {
 
 #[cfg(test)]
 mod tests {
-    use cgmath::{Rad, Vector4};
+    use glam::f32::Vec4;
 
     use super::*;
 
     #[test]
     fn decompose_transform() {
-        let position = -Vector3::new(1.0, 2.0, 3.0);
-        let rotation = make_quat_from_axis_angle(Vector3::new(1.0, 0.2, 3.0).normalize(), Rad(0.2));
-        let scale = Vector3::new(3.0, 2.0, 1.0);
+        let position = -Vec3::new(1.0, 2.0, 3.0);
+        let rotation = make_quat_from_axis_angle(Vec3::new(1.0, 0.2, 3.0).normalize(), 0.2);
+        let scale = Vec3::new(3.0, 2.0, 1.0);
 
         let expected = SimpleTransform {
             position,
@@ -304,148 +280,41 @@ mod tests {
         assert_eq!(transform_1.decompose(), expected);
         assert_eq!(transform_2.decompose(), expected);
         assert_eq!(
-            transform_1.matrix() * Vector4::new(2.0, -3.0, 4.0, 1.0),
+            transform_1.matrix() * Vec4::new(2.0, -3.0, 4.0, 1.0),
             crate::transform::Transform::from(transform_1.decompose()).matrix()
-                * Vector4::new(2.0, -3.0, 4.0, 1.0)
+                * Vec4::new(2.0, -3.0, 4.0, 1.0)
         );
     }
 }
 
-/// from https://stackoverflow.com/questions/4436764/rotating-a-quaternion-on-1-axis
-pub fn make_quat_from_axis_angle(axis: Vector3<f32>, angle: Rad<f32>) -> Quaternion<f32> {
-    let factor = (angle.0 / 2.0).sin();
-
-    let x = axis.x * factor;
-    let y = axis.y * factor;
-    let z = axis.z * factor;
-
-    let w = (angle.0 / 2.0).cos();
-
-    Quaternion::new(w, x, y, z)
+pub fn make_quat_from_axis_angle(axis: Vec3, angle: f32) -> Quat {
+    Quat::from_axis_angle(axis, angle)
 }
 
-/// from https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
-pub fn make_rotation_matrix(r: Quaternion<f32>) -> Matrix4<f32> {
-    let qr = r.s;
-    let qi = r.v.x;
-    let qj = r.v.y;
-    let qk = r.v.z;
-    let qr_2 = qr * qr;
-    let qi_2 = qi * qi;
-    let qj_2 = qj * qj;
-    let qk_2 = qk * qk;
-    let s = (qr_2 + qi_2 + qj_2 + qk_2).sqrt();
+/// from https://en.wikipedia.org/wiki/Quats_and_spatial_rotation#Quat-derived_rotation_matrix
+pub fn make_rotation_matrix(r: Quat) -> Mat4 {
+    Mat4::from_quat(r)
+}
+
+pub fn make_translation_matrix(translation: Vec3) -> Mat4 {
     #[rustfmt::skip]
-    let result = Matrix4::new(
-        1.0 - (2.0 * s * (qj_2 + qk_2)),
-        2.0 * s * (qi*qj - qk*qr),
-        2.0 * s * (qi*qk + qj*qr),
-        0.0,
-  
-        2.0 * s * (qi*qj + qk*qr),
-        1.0 - (2.0 * s * (qi_2 + qk_2)),
-        2.0 * s * (qj*qk - qi*qr),
-        0.0,
-  
-        
-        2.0 * s * (qi*qk - qj*qr),
-        2.0 * s * (qj*qk + qi*qr),
-        1.0 - (2.0 * s * (qi_2 + qj_2)),
-        0.0,
-        
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    ).transpose();
-    result
-}
-
-/// from https://d3cw3dd2w32x2b.cloudfront.net/wp-content/uploads/2015/01/matrix-to-quat.pdf
-pub fn get_quat_from_rotation_matrix(mat: Matrix4<f32>) -> Quaternion<f32> {
-    let (t, q): (f32, Quaternion<f32>) = if mat.z.z < 0.0 {
-        if mat.x.x > mat.y.y {
-            let t = 1.0 + mat.x.x - mat.y.y - mat.z.z;
-            (
-                t,
-                Quaternion::new(mat.y.z - mat.z.y, t, mat.x.y + mat.y.x, mat.x.z + mat.z.x),
-            )
-        } else {
-            let t = 1.0 - mat.x.x + mat.y.y - mat.z.z;
-            (
-                t,
-                Quaternion::new(mat.z.x - mat.x.z, mat.x.y + mat.y.x, t, mat.y.z + mat.z.y),
-            )
-        }
-    } else if mat.x.x < -(mat.y.y) {
-        let t = 1.0 - mat.x.x - mat.y.y + mat.z.z;
-        (
-            t,
-            Quaternion::new(mat.x.y - mat.y.x, mat.z.x + mat.x.z, mat.y.z + mat.z.y, t),
-        )
-    } else {
-        let t = 1.0 + mat.x.x + mat.y.y + mat.z.z;
-        (
-            t,
-            Quaternion::new(t, mat.y.z - mat.z.y, mat.z.x - mat.x.z, mat.x.y - mat.y.x),
-        )
-    };
-    q * (0.5 / t.sqrt())
-}
-
-/// from https://en.wikipedia.org/wiki/Rotation_matrix
-pub fn _make_rotation_matrix_from_eulers(
-    pitch: Rad<f32>,
-    yaw: Rad<f32>,
-    roll: Rad<f32>,
-) -> Matrix4<f32> {
-    let pitch = pitch.0;
-    let yaw = yaw.0;
-    let roll = roll.0;
-    #[rustfmt::skip]
-    let result = Matrix4::new(
-        yaw.cos() * pitch.cos(),
-        yaw.cos() * pitch.sin() * roll.sin() - yaw.sin() * roll.cos(),
-        yaw.cos() * pitch.sin() * roll.cos() + yaw.sin() * roll.sin(),
-        0.0,
-
-        yaw.sin() * pitch.cos(),
-        yaw.sin() * pitch.sin() * roll.sin() + yaw.cos() * roll.cos(),
-        yaw.sin() * pitch.sin() * roll.cos() - yaw.cos() * roll.sin(),
-        0.0,
-
-        -pitch.sin(),
-        pitch.cos() * roll.sin(),
-        pitch.cos() * roll.cos(),
-        0.0,
-        
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    ).transpose();
-    result
-}
-
-pub fn make_translation_matrix(translation: Vector3<f32>) -> Matrix4<f32> {
-    #[rustfmt::skip]
-    let result = Matrix4::new(
+    let result = Mat4::from_cols_array(&[
         1.0, 0.0, 0.0, translation.x,
         0.0, 1.0, 0.0, translation.y,
         0.0, 0.0, 1.0, translation.z,
         0.0, 0.0, 0.0,           1.0,
-    ).transpose();
+    ]).transpose();
     result
 }
 
-pub fn make_scale_matrix(scale: Vector3<f32>) -> Matrix4<f32> {
+pub fn make_scale_matrix(scale: Vec3) -> Mat4 {
     #[rustfmt::skip]
-    let result = Matrix4::new(
+    let result = Mat4::from_cols_array(&[
         scale.x, 0.0,     0.0,     0.0,
         0.0,     scale.y, 0.0,     0.0,
         0.0,     0.0,     scale.z, 0.0,
         0.0,     0.0,     0.0,     1.0,
-    ).transpose();
+    ]).transpose();
     result
 }
 
@@ -453,31 +322,31 @@ pub fn make_scale_matrix(scale: Vector3<f32>) -> Matrix4<f32> {
 pub fn make_perspective_proj_matrix(
     near_plane_distance: f32,
     far_plane_distance: f32,
-    vertical_fov: cgmath::Rad<f32>,
+    vertical_fov: f32,
     aspect_ratio: f32,
     reverse_z: bool,
-) -> Matrix4<f32> {
+) -> Mat4 {
     let n = near_plane_distance;
     let f = far_plane_distance;
-    let cot = 1.0 / (vertical_fov.0 / 2.0).tan();
+    let cot = 1.0 / (vertical_fov / 2.0).tan();
     let ar = aspect_ratio;
     #[rustfmt::skip]
-    let persp_matrix = Matrix4::new(
+    let persp_matrix = Mat4::from_cols_array(&[
         cot/ar, 0.0, 0.0,     0.0,
         0.0,    cot, 0.0,     0.0,
         0.0,    0.0, f/(n-f), n*f/(n-f),
         0.0,    0.0, -1.0,     0.0,
-    ).transpose();
+    ]).transpose();
     if !reverse_z {
         persp_matrix
     } else {
         #[rustfmt::skip]
-        let reverse_z = Matrix4::new(
+        let reverse_z = Mat4::from_cols_array(&[
             1.0, 0.0, 0.0,  0.0,
             0.0, 1.0, 0.0,  0.0,
             0.0, 0.0, -1.0, 1.0,
             0.0, 0.0, 0.0,  1.0,
-        ).transpose();
+        ]).transpose();
         reverse_z * persp_matrix
     }
 }
@@ -488,7 +357,7 @@ pub fn make_orthographic_proj_matrix(
     near_plane: f32,
     far_plane: f32,
     reverse_z: bool,
-) -> Matrix4<f32> {
+) -> Mat4 {
     let l = -width / 2.0;
     let r = width / 2.0;
     let t = height / 2.0;
@@ -496,31 +365,31 @@ pub fn make_orthographic_proj_matrix(
     let n = near_plane;
     let f = far_plane;
     #[rustfmt::skip]
-    let orth_matrix = Matrix4::new(
+    let orth_matrix =  Mat4::from_cols_array(&[
         2.0/(r-l), 0.0,       0.0,       -(r+l)/(r-l),
         0.0,       2.0/(t-b), 0.0,       -(t+b)/(t-b),
         0.0,       0.0,       1.0/(n-f), n/(n-f),
         0.0,       0.0,       0.0,       1.0,
-    ).transpose();
+    ]).transpose();
     if !reverse_z {
         orth_matrix
     } else {
         #[rustfmt::skip]
-        let reverse_z = Matrix4::new(
+        let reverse_z =  Mat4::from_cols_array(&[
             1.0, 0.0, 0.0,  0.0,
             0.0, 1.0, 0.0,  0.0,
             0.0, 0.0, -1.0, 1.0,
             0.0, 0.0, 0.0,  1.0,
-        ).transpose();
+        ]).transpose();
         reverse_z * orth_matrix
     }
 }
 
-pub fn direction_vector_to_coordinate_frame_matrix(dir: Vector3<f32>) -> Matrix4<f32> {
-    look_at_dir(Vector3::new(0.0, 0.0, 0.0), dir)
+pub fn direction_vector_to_coordinate_frame_matrix(dir: Vec3) -> Mat4 {
+    look_at_dir(Vec3::new(0.0, 0.0, 0.0), dir)
 }
 
-pub fn _look_at(eye_pos: Vector3<f32>, dst_pos: Vector3<f32>) -> Matrix4<f32> {
+pub fn _look_at(eye_pos: Vec3, dst_pos: Vec3) -> Mat4 {
     look_at_dir(eye_pos, (dst_pos - eye_pos).normalize())
 }
 
@@ -530,33 +399,34 @@ pub fn _look_at(eye_pos: Vector3<f32>, dst_pos: Vector3<f32>) -> Matrix4<f32> {
 /// into the camera's view space), take the inverse of this matrix
 /// warning: fails if pointing directly upward or downward
 /// a.k.a. if dir.normalize() is approximately (0, 1, 0) or (0, -1, 0)
-pub fn look_at_dir(eye_pos: Vector3<f32>, dir: Vector3<f32>) -> Matrix4<f32> {
-    let world_up = Vector3::new(0.0, 1.0, 0.0);
+pub fn look_at_dir(eye_pos: Vec3, dir: Vec3) -> Mat4 {
+    let world_up = Vec3::new(0.0, 1.0, 0.0);
     let forward = dir.normalize();
     let left = world_up.cross(forward).normalize();
     let camera_up = forward.cross(left).normalize();
     #[rustfmt::skip]
-    let look_at_matrix = Matrix4::new(
+    let look_at_matrix = Mat4::from_cols_array(&[
         left.x, camera_up.x, forward.x, eye_pos.x,
         left.y, camera_up.y, forward.y, eye_pos.y,
         left.z, camera_up.z, forward.z, eye_pos.z,
         0.0,    0.0, 0.0, 1.0,
-    ).transpose();
+    ]).transpose();
     look_at_matrix
 }
-pub fn clear_translation_from_matrix(mut transform: Matrix4<f32>) -> Matrix4<f32> {
-    transform.w.x = 0.0;
-    transform.w.y = 0.0;
-    transform.w.z = 0.0;
+pub fn clear_translation_from_matrix(mut transform: Mat4) -> Mat4 {
+    transform.w_axis.x = 0.0;
+    transform.w_axis.y = 0.0;
+    transform.w_axis.z = 0.0;
     transform
 }
 
-pub fn get_translation_from_matrix(transform: Matrix4<f32>) -> Vector3<f32> {
-    Vector3::new(transform.w.x, transform.w.y, transform.w.z)
+pub fn get_translation_from_matrix(transform: Mat4) -> Vec3 {
+    let (scale, rotation, position) = transform.to_scale_rotation_translation();
+    position
 }
 
-pub fn _matrix_diff(a: Matrix4<f32>, b: Matrix4<f32>) -> f32 {
-    let diff: [[f32; 4]; 4] = (b - a).into();
+pub fn _matrix_diff(a: Mat4, b: Mat4) -> f32 {
+    let diff: [[f32; 4]; 4] = (b - a).to_cols_array_2d();
     let mut total = 0.0;
     for column in diff {
         for val in column {


### PR DESCRIPTION
Taking away the parent index hash map was successful. It sped up the `recompute_node_transforms` function a bit. I also noticed that most of the time was spent doing matrix multiplications and I found two very effective ways to optimize that front:
 
1) Changing from cgmath to glam. As per the [mathbench page](), the "matrix4 mul matrix4" operation is supposed to be around 3x faster on glam vs cgmath, I guess because they use SIMD and cgmath doesn't. Overall it seems like glam is actually a better library than cgmath so I'm happy to change to it 😃. When refactoring the code to use glam, I was able to delete a bunch of code from `math.rs`/`transform.rs` because glam already implemented it 😃.

2) Removing the `base_matrix` attribute from the `Transform` struct. This prevents the need to do a matrix multiplication every time `Transform::matrix()` is called and it makes the struct take up less space, which should improve cache coherency. Interestingly, moving the `is_new` attribute to the top of the Transform struct also helped performance of the `recompute_global_node_transforms` function, maybe because the test on `Mul` implementation allows the cpu to read only the first byte of the struct instead of the whole thing when it's set to true.

Also, the `recompute_node_transforms` function no longer exists. I think it was overcomplicated and probably slower.

As per screenshots below, the execution time is down from ~484us (423 + 61) to 65, around a 7x speedup in total 😃

### Before

![image](https://user-images.githubusercontent.com/2389735/210197334-7ca221ce-e480-46ab-ae34-7d1483c183a6.png)

### After

![image](https://user-images.githubusercontent.com/2389735/210197336-71720808-0fa4-4b98-95a5-dacef0e4c5ba.png)


Closes #48 