### PR TITLE
Gpu profiling soft shadows frustum culling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,8 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-profiler"
-version = "0.11.0"
-source = "git+https://github.com/Davidster/wgpu-profiler.git?branch=wgpu_16#04e98e181c59714772ed36f7bc6dd1bdd842d000"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8545365935dee884288860abc2a6920e904fff8a188205a848234376664796"
 dependencies = [
  "wgpu",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ wgpu = "0.16"
 winit = { version = "0.27", git = "https://github.com/iced-rs/winit.git", rev = "940457522e9fb9f5dac228b0ecfafe0138b4048c" }
 
 # math
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 rapier3d = "0.17"
 glam = { version = "0.23.0", features = ["approx", "bytemuck"] }
 approx = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ env_logger = { version = "0.10", default-features = false, features = [
 log = "0.4"
 
 # profiling
-profiling = "1.0.8"                                                                            # The version should be the one used by wgpu-core/hal
-wgpu-profiler = { git = "https://github.com/Davidster/wgpu-profiler.git", branch = "wgpu_16" }
+profiling = "1.0.8"    # The version should be the one used by wgpu-core/hal TODO: does this version number need updating?
+wgpu-profiler = "0.12"
 
 # assets
 gltf = "1.1"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -113,6 +113,10 @@ impl GpuBuffer {
             true
         }
     }
+
+    pub fn destroy(&self) {
+        self.src.destroy();
+    }
 }
 
 #[derive(Debug)]

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -131,12 +131,12 @@ impl From<ShaderCameraData> for SkyboxShaderCameraRaw {
 pub fn build_cubemap_face_camera_view_directions() -> impl Iterator<Item = ControlledViewDirection>
 {
     vec![
-        (90.0, 0.0),    // right
-        (-90.0, 0.0),   // left
-        (180.0, 90.0),  // top
-        (180.0, -90.0), // bottom
-        (180.0, 0.0),   // front
-        (0.0, 0.0),     // back
+        (90.0, 0.0),    // right (negative x)
+        (-90.0, 0.0),   // left (positive x)
+        (180.0, 90.0),  // top (positive y)
+        (180.0, -90.0), // bottom (negative y)
+        (180.0, 0.0),   // front (position z)
+        (0.0, 0.0),     // back (negative z)
     ]
     .into_iter()
     .map(

--- a/src/character.rs
+++ b/src/character.rs
@@ -4,7 +4,7 @@ use crate::physics::*;
 use crate::renderer::*;
 use crate::scene::*;
 
-use glam::f32::Vec3;
+use glam::Vec4;
 
 pub struct Character {
     root_node_id: GameNodeId,
@@ -26,7 +26,7 @@ impl Character {
         cube_mesh: &BasicMesh,
     ) -> Self {
         let collision_debug_mesh_index =
-            Renderer::bind_basic_unlit_mesh(renderer_base, renderer_data, cube_mesh);
+            Renderer::bind_basic_transparent_mesh(renderer_base, renderer_data, cube_mesh);
         let mut result = Self {
             root_node_id,
             skin_index,
@@ -139,10 +139,10 @@ impl Character {
                             }
                         })
                         .unwrap_or_else(|| vec![self.collision_debug_mesh_index]),
-                    mesh_type: GameNodeMeshType::Unlit {
-                        color: Vec3::new(1.0, 0.0, 0.0),
+                    mesh_type: GameNodeMeshType::Transparent {
+                        color: Vec4::new(1.0, 0.0, 0.0, 0.3),
+                        premultiplied_alpha: false,
                     },
-                    wireframe: true,
                     ..Default::default()
                 })
             }
@@ -166,10 +166,10 @@ impl Character {
                             }
                         })
                         .unwrap_or_else(|| vec![self.collision_debug_mesh_index]),
-                    mesh_type: GameNodeMeshType::Unlit {
-                        color: Vec3::new(rand::random(), rand::random(), rand::random()),
+                    mesh_type: GameNodeMeshType::Transparent {
+                        color: Vec4::new(rand::random(), rand::random(), rand::random(), 0.3),
+                        premultiplied_alpha: false,
                     },
-                    wireframe: true,
                     ..Default::default()
                 })
             }

--- a/src/game.rs
+++ b/src/game.rs
@@ -34,6 +34,12 @@ pub const INITIAL_TONE_MAPPING_EXPOSURE: f32 = 1.0;
 pub const INITIAL_BLOOM_THRESHOLD: f32 = 0.8;
 pub const INITIAL_BLOOM_RAMP_SIZE: f32 = 0.2;
 pub const ARENA_SIDE_LENGTH: f32 = 500.0;
+pub const INITIAL_ENABLE_SHADOW_DEBUG: bool = false;
+pub const INITIAL_ENABLE_SOFT_SHADOWS: bool = true;
+pub const INITIAL_SHADOW_BIAS: f32 = 0.0005;
+pub const INITIAL_SOFT_SHADOW_FACTOR: f32 = 0.0015;
+pub const INITIAL_SOFT_SHADOW_GRID_DIMS: u32 = 4;
+
 // pub const LIGHT_COLOR_A: Vec3 = Vec3::new(0.996, 0.973, 0.663);
 // pub const LIGHT_COLOR_B: Vec3 = Vec3::new(0.25, 0.973, 0.663);
 
@@ -1026,7 +1032,7 @@ pub fn update_game_state(
         if let Entry::Occupied(entry) = loaded_audio_guard.entry("./src/sounds/bgm.mp3".to_string())
         {
             let (_, bgm_sound_index) = entry.remove_entry();
-            audio_manager_guard.play_sound(bgm_sound_index);
+            // audio_manager_guard.play_sound(bgm_sound_index);
             game_state.bgm_sound_index = Some(bgm_sound_index);
             // logger_log("loaded bgm sound");
         }

--- a/src/game.rs
+++ b/src/game.rs
@@ -1032,7 +1032,7 @@ pub fn update_game_state(
         if let Entry::Occupied(entry) = loaded_audio_guard.entry("./src/sounds/bgm.mp3".to_string())
         {
             let (_, bgm_sound_index) = entry.remove_entry();
-            // audio_manager_guard.play_sound(bgm_sound_index);
+            audio_manager_guard.play_sound(bgm_sound_index);
             game_state.bgm_sound_index = Some(bgm_sound_index);
             // logger_log("loaded bgm sound");
         }

--- a/src/game.rs
+++ b/src/game.rs
@@ -166,8 +166,10 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
         // load in gltf files
 
         // player's revolver
+        // https://done3d.com/colt-python-8-inch/
         asset_loader.load_gltf_asset("./src/models/gltf/ColtPython/colt_python.gltf");
         // forest
+        // https://sketchfab.com/3d-models/free-low-poly-forest-6dc8c85121234cb59dbd53a673fa2b8f
         asset_loader.load_gltf_asset("./src/models/gltf/free_low_poly_forest/scene.gltf");
         // legendary robot
         // https://www.cgtrader.com/free-3d-models/character/sci-fi-character/legendary-robot-free-low-poly-3d-model

--- a/src/game.rs
+++ b/src/game.rs
@@ -35,6 +35,7 @@ pub const INITIAL_BLOOM_THRESHOLD: f32 = 0.8;
 pub const INITIAL_BLOOM_RAMP_SIZE: f32 = 0.2;
 pub const ARENA_SIDE_LENGTH: f32 = 500.0;
 pub const INITIAL_ENABLE_SHADOW_DEBUG: bool = false;
+pub const INITIAL_ENABLE_CULLING_FRUSTUM_DEBUG: bool = false;
 pub const INITIAL_ENABLE_SOFT_SHADOWS: bool = true;
 pub const INITIAL_SHADOW_BIAS: f32 = 0.0005;
 pub const INITIAL_SOFT_SHADOW_FACTOR: f32 = 0.0015;
@@ -168,9 +169,9 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
         // https://www.cgtrader.com/free-3d-models/character/sci-fi-character/legendary-robot-free-low-poly-3d-model
         asset_loader.load_gltf_asset("./src/models/gltf/LegendaryRobot/Legendary_Robot.gltf");
         // maze
-        // asset_loader.load_gltf_asset("./src/models/gltf/TestLevel/test_level.gltf");
+        asset_loader.load_gltf_asset("./src/models/gltf/TestLevel/test_level.gltf");
         // other
-        asset_loader.load_gltf_asset(get_misc_gltf_path());
+        // asset_loader.load_gltf_asset(get_misc_gltf_path());
 
         asset_loader.load_audio(
             "./src/sounds/bgm.mp3",
@@ -198,18 +199,18 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
 
     // add lights to the scene
     let directional_lights = vec![
-        DirectionalLightComponent {
-            position: Vec3::new(1.0, 5.0, -10.0) * 10.0,
-            direction: (-Vec3::new(1.0, 5.0, -10.0)).normalize(),
-            color: DIRECTIONAL_LIGHT_COLOR_A,
-            intensity: 1.0,
-        },
-        DirectionalLightComponent {
-            position: Vec3::new(-1.0, 10.0, 10.0) * 10.0,
-            direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
-            color: DIRECTIONAL_LIGHT_COLOR_B,
-            intensity: 1.0,
-        },
+        // DirectionalLightComponent {
+        //     position: Vec3::new(1.0, 5.0, -10.0) * 10.0,
+        //     direction: (-Vec3::new(1.0, 5.0, -10.0)).normalize(),
+        //     color: DIRECTIONAL_LIGHT_COLOR_A,
+        //     intensity: 1.0,
+        // },
+        // DirectionalLightComponent {
+        //     position: Vec3::new(-1.0, 10.0, 10.0) * 10.0,
+        //     direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
+        //     color: DIRECTIONAL_LIGHT_COLOR_B,
+        //     intensity: 1.0,
+        // },
     ];
     // let directional_lights: Vec<DirectionalLightComponent> = vec![];
 
@@ -217,7 +218,7 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
         (
             TransformBuilder::new()
                 .scale(Vec3::new(0.05, 0.05, 0.05))
-                .position(Vec3::new(0.0, 12.0, 0.0))
+                .position(Vec3::new(0.0, 0.0, 0.0))
                 .build(),
             POINT_LIGHT_COLOR,
             1.0,
@@ -432,14 +433,14 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
                 )))
                 .transform(
                     TransformBuilder::new()
-                        .position(Vec3::new(4.0, 10.0, 4.0))
-                        // .scale(Vec3::new(0.0, 0.0, 0.0))
+                        .position(Vec3::new(4.0, 1.5, 3.0))
+                        .scale(0.2 * Vec3::new(1.0, 1.0, 1.0))
                         .build(),
                 )
                 .build(),
         )
         .id();
-    scene.remove_node(test_object_node_id);
+    // scene.remove_node(test_object_node_id);
 
     // add floor to scene
 
@@ -1145,11 +1146,14 @@ pub fn update_game_state(
         //     (global_time_seconds * 2.0).sin(),
         // );
         if let Some(node) = game_state.scene.get_node_mut(point_light_0.node_id) {
-            node.transform.set_position(Vec3::new(
-                1.5 * (global_time_seconds * 0.25 + std::f32::consts::PI).cos(),
-                node.transform.position().y - frame_time_seconds * 0.25,
-                1.5 * (global_time_seconds * 0.25 + std::f32::consts::PI).sin(),
-            ));
+            node.transform.set_position(
+                Vec3::new(3.0, 0.0, 0.0)
+                    + Vec3::new(
+                        1.5 * (global_time_seconds * 0.25 + std::f32::consts::PI).cos(),
+                        3.0,
+                        1.5 * (global_time_seconds * 0.25 + std::f32::consts::PI).sin(),
+                    ),
+            );
         }
     }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -36,6 +36,7 @@ pub const INITIAL_BLOOM_RAMP_SIZE: f32 = 0.2;
 pub const ARENA_SIDE_LENGTH: f32 = 500.0;
 pub const INITIAL_ENABLE_SHADOW_DEBUG: bool = false;
 pub const INITIAL_ENABLE_CULLING_FRUSTUM_DEBUG: bool = false;
+pub const INITIAL_ENABLE_POINT_LIGHT_CULLING_FRUSTUM_DEBUG: bool = false;
 pub const INITIAL_ENABLE_SOFT_SHADOWS: bool = true;
 pub const INITIAL_SHADOW_BIAS: f32 = 0.0005;
 pub const INITIAL_SOFT_SHADOW_FACTOR: f32 = 0.0015;
@@ -205,12 +206,12 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
         //     color: DIRECTIONAL_LIGHT_COLOR_A,
         //     intensity: 1.0,
         // },
-        // DirectionalLightComponent {
-        //     position: Vec3::new(-1.0, 10.0, 10.0) * 10.0,
-        //     direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
-        //     color: DIRECTIONAL_LIGHT_COLOR_B,
-        //     intensity: 1.0,
-        // },
+        DirectionalLightComponent {
+            position: Vec3::new(-1.0, 10.0, 10.0) * 10.0,
+            direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
+            color: DIRECTIONAL_LIGHT_COLOR_B,
+            intensity: 1.0,
+        },
     ];
     // let directional_lights: Vec<DirectionalLightComponent> = vec![];
 
@@ -223,14 +224,14 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
             POINT_LIGHT_COLOR,
             1.0,
         ),
-        // (
-        //     TransformBuilder::new()
-        //         .scale(Vec3::new(0.1, 0.1, 0.1))
-        //         .position(Vec3::new(0.0, 15.0, 0.0))
-        //         .build(),
-        //     LIGHT_COLOR_B,
-        //     1.0,
-        // ),
+        (
+            TransformBuilder::new()
+                .scale(Vec3::new(0.1, 0.1, 0.1))
+                .position(Vec3::new(0.0, 15.0, 0.0))
+                .build(),
+            DIRECTIONAL_LIGHT_COLOR_B,
+            1.0,
+        ),
     ];
     // let point_lights: Vec<(crate::transform::Transform, Vec3, f32)> = vec![];
 
@@ -469,7 +470,7 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
         ball_node_ids.push(node.id());
     }
 
-    let physics_ball_count = 500;
+    let physics_ball_count = 0;
     let physics_balls: Vec<_> = (0..physics_ball_count)
         .map(|_| {
             PhysicsBall::new_random(
@@ -1196,7 +1197,7 @@ pub fn update_game_state(
             // let color = lerp_vec(LIGHT_COLOR_B, LIGHT_COLOR_A, (time_seconds * 2.0).sin());
 
             DirectionalLightComponent {
-                direction: Vec3::new(direction.x, direction.y + 0.0001, direction.z),
+                direction: Vec3::new(direction.x, direction.y + 0.00001, direction.z),
                 ..*directional_light_0
             }
         });
@@ -1320,10 +1321,7 @@ pub fn update_game_state(
             let player_position = game_state
                 .player_controller
                 .position(&game_state.physics_state);
-            let direction_vec = game_state
-                .player_controller
-                .view_direction
-                .to_direction_vector();
+            let direction_vec = game_state.player_controller.view_direction.to_vector();
             let ray = Ray::new(
                 point![player_position.x, player_position.y, player_position.z],
                 vector![direction_vec.x, direction_vec.y, direction_vec.z],

--- a/src/game.rs
+++ b/src/game.rs
@@ -170,7 +170,7 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
         // https://www.cgtrader.com/free-3d-models/character/sci-fi-character/legendary-robot-free-low-poly-3d-model
         asset_loader.load_gltf_asset("./src/models/gltf/LegendaryRobot/Legendary_Robot.gltf");
         // maze
-        asset_loader.load_gltf_asset("./src/models/gltf/TestLevel/test_level.gltf");
+        // asset_loader.load_gltf_asset("./src/models/gltf/TestLevel/test_level.gltf");
         // other
         // asset_loader.load_gltf_asset(get_misc_gltf_path());
 
@@ -206,12 +206,12 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
         //     color: DIRECTIONAL_LIGHT_COLOR_A,
         //     intensity: 1.0,
         // },
-        DirectionalLightComponent {
-            position: Vec3::new(-1.0, 10.0, 10.0) * 10.0,
-            direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
-            color: DIRECTIONAL_LIGHT_COLOR_B,
-            intensity: 1.0,
-        },
+        // DirectionalLightComponent {
+        //     position: Vec3::new(-1.0, 10.0, 10.0) * 10.0,
+        //     direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
+        //     color: DIRECTIONAL_LIGHT_COLOR_B,
+        //     intensity: 1.0,
+        // },
     ];
     // let directional_lights: Vec<DirectionalLightComponent> = vec![];
 
@@ -224,14 +224,14 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
             POINT_LIGHT_COLOR,
             1.0,
         ),
-        (
-            TransformBuilder::new()
-                .scale(Vec3::new(0.1, 0.1, 0.1))
-                .position(Vec3::new(0.0, 15.0, 0.0))
-                .build(),
-            DIRECTIONAL_LIGHT_COLOR_B,
-            1.0,
-        ),
+        // (
+        //     TransformBuilder::new()
+        //         .scale(Vec3::new(0.1, 0.1, 0.1))
+        //         .position(Vec3::new(0.0, 15.0, 0.0))
+        //         .build(),
+        //     DIRECTIONAL_LIGHT_COLOR_B,
+        //     1.0,
+        // ),
     ];
     // let point_lights: Vec<(crate::transform::Transform, Vec3, f32)> = vec![];
 
@@ -527,6 +527,22 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
             .transform(floor_transform)
             .build(),
     );
+    // let ceiling_transform = TransformBuilder::new()
+    //     .position(Vec3::new(0.0, 10.0, 0.0))
+    //     .scale(Vec3::new(ARENA_SIDE_LENGTH, 1.0, ARENA_SIDE_LENGTH))
+    //     .rotation(make_quat_from_axis_angle(
+    //         Vec3::new(1.0, 0.0, 0.0),
+    //         deg_to_rad(180.0),
+    //     ))
+    //     .build();
+    // let _ceiling_node = scene.add_node(
+    //     GameNodeDescBuilder::new()
+    //         .mesh(Some(GameNodeMesh::from_pbr_mesh_index(
+    //             floor_pbr_mesh_index,
+    //         )))
+    //         .transform(ceiling_transform)
+    //         .build(),
+    // );
     let floor_thickness = 0.1;
     let floor_collider = ColliderBuilder::cuboid(
         floor_transform.scale().x,

--- a/src/gameloop.rs
+++ b/src/gameloop.rs
@@ -87,6 +87,10 @@ pub fn run(
                         .ui_overlay
                         .get_state()
                         .draw_culling_frustum;
+                    renderer_data_guard.draw_point_light_culling_frusta = renderer_data_guard
+                        .ui_overlay
+                        .get_state()
+                        .draw_point_light_culling_frusta;
 
                     renderer.set_culling_frustum_lock(
                         &game_state,

--- a/src/gameloop.rs
+++ b/src/gameloop.rs
@@ -28,17 +28,7 @@ pub fn run(
             Event::RedrawRequested(_) => {
                 game_state.on_frame_started();
                 profiling::finish_frame!();
-                if let Some(last_frame_start_time) = last_frame_start_time {
-                    let mut renderer_data_guard = renderer.data.lock().unwrap();
-                    renderer_data_guard.ui_overlay.send_message(
-                        crate::ui_overlay::Message::FrameCompleted(last_frame_start_time.elapsed()),
-                    );
-                    if let Some(gpu_timing_info) = renderer.process_profiler_frame() {
-                        renderer_data_guard.ui_overlay.send_message(
-                            crate::ui_overlay::Message::GpuFrameCompleted(gpu_timing_info),
-                        );
-                    }
-                }
+                let frame_duration = last_frame_start_time.map(|time| time.elapsed());
                 last_frame_start_time = Some(Instant::now());
 
                 update_game_state(&mut game_state, &renderer.base, renderer.data.clone());
@@ -63,8 +53,33 @@ pub fn run(
                 }
 
                 {
+                    // sync UI
                     // TODO: move this into a function in game module?
+
                     let mut renderer_data_guard = renderer.data.lock().unwrap();
+
+                    if let Some(frame_duration) = frame_duration {
+                        renderer_data_guard.ui_overlay.send_message(
+                            crate::ui_overlay::Message::FrameCompleted(frame_duration),
+                        );
+                        if let Some(gpu_timing_info) = renderer.process_profiler_frame() {
+                            renderer_data_guard.ui_overlay.send_message(
+                                crate::ui_overlay::Message::GpuFrameCompleted(gpu_timing_info),
+                            );
+                        }
+                    }
+
+                    let camera_position = game_state
+                        .player_controller
+                        .position(&game_state.physics_state);
+                    let camera_view_direction = game_state.player_controller.view_direction;
+                    renderer_data_guard.ui_overlay.send_message(
+                        crate::ui_overlay::Message::CameraPoseChanged((
+                            camera_position,
+                            camera_view_direction,
+                        )),
+                    );
+
                     renderer_data_guard.enable_soft_shadows = renderer_data_guard
                         .ui_overlay
                         .get_state()

--- a/src/gameloop.rs
+++ b/src/gameloop.rs
@@ -63,6 +63,7 @@ pub fn run(
                 }
 
                 {
+                    // TODO: move this into a function in game module?
                     let mut renderer_data_guard = renderer.data.lock().unwrap();
                     renderer_data_guard.enable_soft_shadows = renderer_data_guard
                         .ui_overlay
@@ -82,6 +83,18 @@ pub fn run(
                         .ui_overlay
                         .get_state()
                         .soft_shadow_grid_dims;
+                    renderer_data_guard.draw_culling_frustum = renderer_data_guard
+                        .ui_overlay
+                        .get_state()
+                        .draw_culling_frustum;
+
+                    renderer.set_culling_frustum_lock(
+                        &game_state,
+                        renderer_data_guard
+                            .ui_overlay
+                            .get_state()
+                            .culling_frustum_lock_mode,
+                    )
                 }
 
                 match renderer.render(&mut game_state, &window, control_flow) {

--- a/src/gameloop.rs
+++ b/src/gameloop.rs
@@ -62,6 +62,28 @@ pub fn run(
                     _ => {}
                 }
 
+                {
+                    let mut renderer_data_guard = renderer.data.lock().unwrap();
+                    renderer_data_guard.enable_soft_shadows = renderer_data_guard
+                        .ui_overlay
+                        .get_state()
+                        .enable_soft_shadows;
+                    renderer_data_guard.soft_shadow_factor = renderer_data_guard
+                        .ui_overlay
+                        .get_state()
+                        .soft_shadow_factor;
+                    renderer_data_guard.shadow_bias =
+                        renderer_data_guard.ui_overlay.get_state().shadow_bias;
+                    renderer_data_guard.enable_shadow_debug = renderer_data_guard
+                        .ui_overlay
+                        .get_state()
+                        .enable_shadow_debug;
+                    renderer_data_guard.soft_shadow_grid_dims = renderer_data_guard
+                        .ui_overlay
+                        .get_state()
+                        .soft_shadow_grid_dims;
+                }
+
                 match renderer.render(&mut game_state, &window, control_flow) {
                     Ok(_) => {}
                     // Reconfigure the surface if lost

--- a/src/gltf_loader.rs
+++ b/src/gltf_loader.rs
@@ -1,4 +1,5 @@
 use crate::buffer::*;
+use crate::logger::*;
 use crate::mesh::*;
 use crate::renderer::*;
 use crate::sampler_cache::*;
@@ -19,6 +20,7 @@ use approx::abs_diff_eq;
 use glam::f32::{Mat4, Vec2, Vec3, Vec4};
 
 const USE_TEXTURE_COMPRESSION: bool = true;
+const SCENE_LOAD_DEBUG: bool = false;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct ChannelPropertyStr<'a>(&'a str);
@@ -297,32 +299,39 @@ pub fn build_scene(
     let render_buffers = RenderBuffers {
         binded_pbr_meshes,
         binded_unlit_meshes: vec![],
+        binded_transparent_meshes: vec![],
         binded_wireframe_meshes,
         textures,
     };
 
-    /* logger_log("Scene loaded:");
+    if SCENE_LOAD_DEBUG {
+        logger_log("Scene loaded:");
 
-    logger_log(&format!("  - node count: {:?}", nodes.len()));
-    logger_log(&format!("  - skin count: {:?}", skins.len()));
-    logger_log(&format!("  - animation count: {:?}", animations.len()));
-    logger_log("  Render buffers:");
-    logger_log(&format!(
-        "    - PBR mesh count: {:?}",
-        render_buffers.binded_pbr_meshes.len()
-    ));
-    logger_log(&format!(
-        "    - Unlit mesh count: {:?}",
-        render_buffers.binded_unlit_meshes.len()
-    ));
-    logger_log(&format!(
-        "    - Wireframe mesh count: {:?}",
-        render_buffers.binded_wireframe_meshes.len()
-    ));
-    logger_log(&format!(
-        "    - Texture count: {:?}",
-        render_buffers.textures.len()
-    )); */
+        logger_log(&format!("  - node count: {:?}", nodes.len()));
+        logger_log(&format!("  - skin count: {:?}", skins.len()));
+        logger_log(&format!("  - animation count: {:?}", animations.len()));
+        logger_log("  Render buffers:");
+        logger_log(&format!(
+            "    - PBR mesh count: {:?}",
+            render_buffers.binded_pbr_meshes.len()
+        ));
+        logger_log(&format!(
+            "    - Unlit mesh count: {:?}",
+            render_buffers.binded_unlit_meshes.len()
+        ));
+        logger_log(&format!(
+            "    - Transparent mesh count: {:?}",
+            render_buffers.binded_transparent_meshes.len()
+        ));
+        logger_log(&format!(
+            "    - Wireframe mesh count: {:?}",
+            render_buffers.binded_wireframe_meshes.len()
+        ));
+        logger_log(&format!(
+            "    - Texture count: {:?}",
+            render_buffers.textures.len()
+        ));
+    }
 
     let scene = Scene::new(nodes, skins, animations);
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -19,3 +19,7 @@ pub fn lerp_vec(a: Vec3, b: Vec3, alpha: f32) -> Vec3 {
 pub fn deg_to_rad(deg: f32) -> f32 {
     deg * std::f32::consts::PI / 180.0
 }
+
+pub fn rad_to_deg(rad: f32) -> f32 {
+    rad * 180.0 / std::f32::consts::PI
+}

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -60,16 +60,17 @@ impl Default for Vertex {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct GpuPbrMeshInstance {
-    model_transform: Mat4,
-    base_color_factor: [f32; 4],
-    emissive_factor: [f32; 4],
-    mrno: [f32; 4], // metallic_factor, roughness_factor, normal scale, occlusion strength
-    alpha_cutoff: f32,
-    padding: [f32; 3],
+    pub model_transform: Mat4,
+    pub base_color_factor: [f32; 4],
+    pub emissive_factor: [f32; 4],
+    pub mrno: [f32; 4], // metallic_factor, roughness_factor, normal scale, occlusion strength
+    pub alpha_cutoff: f32,
+    pub culling_mask: u32,
+    pub padding: [f32; 2],
 }
 
 impl GpuPbrMeshInstance {
-    pub fn new(transform: Mat4, pbr_params: DynamicPbrParams) -> Self {
+    pub fn new(transform: Mat4, pbr_params: DynamicPbrParams, culling_mask: u32) -> Self {
         let DynamicPbrParams {
             base_color_factor,
             emissive_factor,
@@ -95,7 +96,8 @@ impl GpuPbrMeshInstance {
                 occlusion_strength,
             ],
             alpha_cutoff,
-            padding: [0.0, 0.0, 0.0],
+            culling_mask,
+            padding: [0.0, 0.0],
         }
     }
 }

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -42,6 +42,21 @@ impl Vertex {
     }
 }
 
+impl Default for Vertex {
+    fn default() -> Self {
+        Self {
+            position: Default::default(),
+            normal: [0.0, 1.0, 0.0],
+            tex_coords: Default::default(),
+            tangent: [1.0, 0.0, 0.0],
+            bitangent: [0.0, 0.0, 1.0],
+            color: [1.0, 1.0, 1.0, 1.0],
+            bone_indices: Default::default(),
+            bone_weights: [1.0, 0.0, 0.0, 0.0],
+        }
+    }
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct GpuPbrMeshInstance {
@@ -93,6 +108,8 @@ pub struct GpuUnlitMeshInstance {
 }
 
 pub type GpuWireframeMeshInstance = GpuUnlitMeshInstance;
+
+pub type GpuTransparentMeshInstance = GpuUnlitMeshInstance;
 
 #[derive(Copy, Clone, Debug)]
 pub struct DynamicPbrParams {
@@ -239,9 +256,7 @@ impl BasicMesh {
                             tex_coords: [tex_coords.x, tex_coords.y],
                             tangent: to_arr(&tangent),
                             bitangent: to_arr(&bitangent),
-                            color: [1.0, 1.0, 1.0, 1.0],
-                            bone_indices: [0, 0, 0, 0],
-                            bone_weights: [1.0, 0.0, 0.0, 0.0],
+                            ..Default::default()
                         });
                     }
                 });

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -94,6 +94,9 @@ impl PhysicsState {
                         GameNodeMeshType::Unlit { .. } => {
                             renderer_data.binded_unlit_meshes[*mesh_index].bounding_box
                         }
+                        GameNodeMeshType::Transparent { .. } => {
+                            renderer_data.binded_transparent_meshes[*mesh_index].bounding_box
+                        }
                     };
                     let base_scale = (bounding_box.max - bounding_box.min) / 2.0;
                     let base_position = (bounding_box.max + bounding_box.min) / 2.0;

--- a/src/player_controller.rs
+++ b/src/player_controller.rs
@@ -54,7 +54,7 @@ impl ControlledViewDirection {
             * Quat::from_euler(EulerRot::XYZ, self.vertical, 0.0, 0.0)
     }
 
-    pub fn to_direction_vector(self) -> Vec3 {
+    pub fn to_vector(self) -> Vec3 {
         let horizontal_scale = self.vertical.cos();
         Vec3::new(
             (self.horizontal + std::f32::consts::PI).sin() * horizontal_scale,
@@ -238,7 +238,7 @@ impl PlayerController {
         }
         self.unprocessed_delta = None;
 
-        let forward_direction = self.view_direction.to_direction_vector();
+        let forward_direction = self.view_direction.to_vector();
         let up_direction = Vec3::new(0.0, 1.0, 0.0);
         let right_direction = forward_direction.cross(up_direction);
 
@@ -315,7 +315,7 @@ impl PlayerController {
     }
 
     pub fn view_forward_vector(&self) -> Vec3 {
-        self.view_direction.to_direction_vector()
+        self.view_direction.to_vector()
     }
 
     #[allow(dead_code)]
@@ -324,7 +324,7 @@ impl PlayerController {
     }
 
     pub fn view_frustum_with_position(&self, aspect_ratio: f32, camera_position: Vec3) -> Frustum {
-        let camera_forward = self.view_direction.to_direction_vector();
+        let camera_forward = self.view_direction.to_vector();
         let camera_right = camera_forward.cross(Vec3::new(0.0, 1.0, 0.0)).normalize();
 
         Frustum::from_camera_params(

--- a/src/player_controller.rs
+++ b/src/player_controller.rs
@@ -314,8 +314,16 @@ impl PlayerController {
         Vec3::new(position.x, position.y, position.z)
     }
 
-    pub fn frustum(&self, physics_state: &PhysicsState, aspect_ratio: f32) -> Frustum {
-        let camera_position = self.position(physics_state);
+    pub fn view_forward_vector(&self) -> Vec3 {
+        self.view_direction.to_direction_vector()
+    }
+
+    #[allow(dead_code)]
+    pub fn view_frustum(&self, physics_state: &PhysicsState, aspect_ratio: f32) -> Frustum {
+        self.view_frustum_with_position(aspect_ratio, self.position(physics_state))
+    }
+
+    pub fn view_frustum_with_position(&self, aspect_ratio: f32, camera_position: Vec3) -> Frustum {
         let camera_forward = self.view_direction.to_direction_vector();
         let camera_right = camera_forward.cross(Vec3::new(0.0, 1.0, 0.0)).normalize();
 

--- a/src/player_controller.rs
+++ b/src/player_controller.rs
@@ -131,7 +131,7 @@ impl PlayerController {
                 let scroll_direction = if scroll_amount > 0.0 { 1.0 } else { -1.0 };
                 let scroll_speed = 1.0;
                 self.speed = (self.speed - (scroll_direction * scroll_speed)).clamp(0.5, 300.0);
-                logger_log(&format!("Speed: {:?}", self.speed));
+                // logger_log(&format!("Speed: {:?}", self.speed));
             }
             _ => {}
         };

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -2915,8 +2915,6 @@ impl Renderer {
     // mapping frusta and the rest of the bits represent the point light shadow
     // mapping frusta, of which there are 6 per point light so 6 bits are used
     // per point light.
-    // TODO: u32 can only store a max of 5 point lights, might be worth using a larger
-    // bitvec or a Vec<bool> or something
     fn get_node_culling_mask(
         node: &GameNode,
         data: &RendererPublicData,
@@ -2924,6 +2922,10 @@ impl Renderer {
         camera_culling_frustum: &Frustum,
         point_lights_frusta: &Vec<Option<Vec<Frustum>>>,
     ) -> u32 {
+        assert!(1 + game_state.directional_lights.len() + point_lights_frusta.len() * 6 <= 32, 
+            "u32 can only store a max of 5 point lights, might be worth using a larger, might be worth using a larger bitvec or a Vec<bool> or something"
+        );
+
         if node.mesh.is_none() {
             return 0;
         }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -7,7 +7,6 @@ use crate::light::*;
 use crate::logger::*;
 use crate::math::*;
 use crate::mesh::*;
-use crate::player_controller::*;
 use crate::sampler_cache::*;
 use crate::scene::*;
 use crate::skinning::*;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -102,6 +102,15 @@ struct DirectionalLightUniform {
     color: [f32; 4],
 }
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Default)]
+struct PbrShaderOptionsUniform {
+    options_1: [f32; 4],
+    options_2: [f32; 4],
+    options_3: [f32; 4],
+    options_4: [f32; 4],
+}
+
 impl From<&DirectionalLightComponent> for DirectionalLightUniform {
     fn from(light: &DirectionalLightComponent) -> Self {
         let DirectionalLightComponent {
@@ -151,6 +160,29 @@ fn make_directional_light_uniform_buffer(
     light_uniforms.append(&mut inactive_lights);
 
     light_uniforms
+}
+
+fn make_pbr_shader_options_uniform_buffer(
+    enable_soft_shadows: bool,
+    shadow_bias: f32,
+    soft_shadow_factor: f32,
+    enable_shadow_debug: bool,
+    soft_shadow_grid_dims: u32,
+) -> PbrShaderOptionsUniform {
+    let options_1 = [
+        if enable_soft_shadows { 1.0 } else { 0.0 },
+        soft_shadow_factor,
+        if enable_shadow_debug { 1.0 } else { 0.0 },
+        soft_shadow_grid_dims as f32,
+    ];
+
+    let options_2 = [shadow_bias, 0.0, 0.0, 0.0];
+
+    PbrShaderOptionsUniform {
+        options_1,
+        options_2,
+        ..Default::default()
+    }
 }
 
 #[repr(C)]
@@ -285,7 +317,14 @@ impl BaseRenderer {
         let adapter_info = adapter.get_info();
         log::info!("Using {} ({:?})", adapter_info.name, adapter_info.backend);
 
-        let features = adapter.features();
+        let mut features = adapter.features();
+
+        // use time features if they're available on the adapter
+        features &= wgpu_profiler::GpuProfiler::ALL_WGPU_TIMER_FEATURES;
+
+        // panic if these features are missing
+        features |= wgpu::Features::PUSH_CONSTANTS;
+        features |= wgpu::Features::TEXTURE_COMPRESSION_BC;
 
         let (device, queue) = adapter
             .request_device(
@@ -667,7 +706,7 @@ pub struct RendererPrivateData {
     bloom_threshold_cleared: bool,
 
     // gpu
-    lights_bind_group: wgpu::BindGroup,
+    lights_and_pbr_shader_options_bind_group: wgpu::BindGroup,
     bones_and_pbr_instances_bind_group: wgpu::BindGroup,
     bones_and_unlit_instances_bind_group: wgpu::BindGroup,
     bones_and_wireframe_instances_bind_group: wgpu::BindGroup,
@@ -680,6 +719,7 @@ pub struct RendererPrivateData {
 
     point_lights_buffer: wgpu::Buffer,
     directional_lights_buffer: wgpu::Buffer,
+    pbr_shader_options_buffer: wgpu::Buffer,
     bones_buffer: GpuBuffer,
     pbr_instances_buffer: GpuBuffer,
     unlit_instances_buffer: GpuBuffer,
@@ -717,6 +757,11 @@ pub struct RendererPublicData {
     pub enable_shadows: bool,
     pub enable_wireframe_mode: bool,
     pub draw_node_bounding_spheres: bool,
+    pub enable_soft_shadows: bool,
+    pub shadow_bias: f32,
+    pub soft_shadow_factor: f32,
+    pub enable_shadow_debug: bool,
+    pub soft_shadow_grid_dims: u32,
 
     pub ui_overlay: IkariUiOverlay,
 }
@@ -950,7 +995,7 @@ impl Renderer {
                     label: Some("single_uniform_bind_group_layout"),
                 });
 
-        let lights_bind_group_layout =
+        let lights_and_pbr_shader_options_bind_group_layout =
             base.device
                 .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     entries: &[
@@ -974,8 +1019,18 @@ impl Renderer {
                             },
                             count: None,
                         },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 2,
+                            visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Uniform,
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
                     ],
-                    label: Some("lights_uniform_bind_group_layout"),
+                    label: Some("lights_and_shader_options_bind_group_layout"),
                 });
 
         let fragment_shader_color_targets = &[Some(wgpu::ColorTargetState {
@@ -999,7 +1054,7 @@ impl Renderer {
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: Some("Mesh Pipeline Layout"),
                     bind_group_layouts: &[
-                        &lights_bind_group_layout,
+                        &lights_and_pbr_shader_options_bind_group_layout,
                         &environment_textures_bind_group_layout,
                         &base.bones_and_instances_bind_group_layout,
                         &base.pbr_textures_bind_group_layout,
@@ -1053,7 +1108,7 @@ impl Renderer {
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: Some("Unlit Mesh Pipeline Layout"),
                     bind_group_layouts: &[
-                        &lights_bind_group_layout,
+                        &lights_and_pbr_shader_options_bind_group_layout,
                         &base.bones_and_instances_bind_group_layout,
                     ],
                     push_constant_ranges: &[mesh_camera_push_constant_range.clone()],
@@ -1426,7 +1481,7 @@ impl Renderer {
                 .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                     label: Some("Shadow Map Pipeline Layout"),
                     bind_group_layouts: &[
-                        &lights_bind_group_layout,
+                        &lights_and_pbr_shader_options_bind_group_layout,
                         &base.bones_and_instances_bind_group_layout,
                     ],
                     push_constant_ranges: &[mesh_camera_push_constant_range],
@@ -1791,20 +1846,45 @@ impl Renderer {
                     usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
                 });
 
-        let lights_bind_group = base.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &lights_bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: point_lights_buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: directional_lights_buffer.as_entire_binding(),
-                },
-            ],
-            label: Some("lights_bind_group"),
-        });
+        let enable_soft_shadows = Default::default();
+        let shadow_bias = Default::default();
+        let soft_shadow_factor = Default::default();
+        let enable_shadow_debug = Default::default();
+        let soft_shadow_grid_dims = Default::default();
+        let initial_pbr_shader_options_buffer = make_pbr_shader_options_uniform_buffer(
+            enable_soft_shadows,
+            shadow_bias,
+            soft_shadow_factor,
+            enable_shadow_debug,
+            soft_shadow_grid_dims,
+        );
+        let pbr_shader_options_buffer =
+            base.device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("PBR Shader Options Buffer"),
+                    contents: bytemuck::cast_slice(&[initial_pbr_shader_options_buffer]),
+                    usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                });
+
+        let lights_and_pbr_shader_options_bind_group =
+            base.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                layout: &lights_and_pbr_shader_options_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: point_lights_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: directional_lights_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: pbr_shader_options_buffer.as_entire_binding(),
+                    },
+                ],
+                label: Some("lights_and_pbr_shader_options_bind_group"),
+            });
 
         let bones_buffer = GpuBuffer::empty(
             &base.device,
@@ -2021,10 +2101,16 @@ impl Renderer {
             bloom_threshold: INITIAL_BLOOM_THRESHOLD,
             bloom_ramp_size: INITIAL_BLOOM_RAMP_SIZE,
             render_scale: initial_render_scale,
-            enable_bloom: true,
-            enable_shadows: true,
+            enable_bloom: false,
+            enable_shadows: false,
             enable_wireframe_mode: false,
             draw_node_bounding_spheres: false,
+
+            enable_soft_shadows,
+            shadow_bias,
+            soft_shadow_factor,
+            enable_shadow_debug,
+            soft_shadow_grid_dims,
 
             ui_overlay,
         };
@@ -2067,7 +2153,7 @@ impl Renderer {
 
                 bloom_threshold_cleared: true,
 
-                lights_bind_group,
+                lights_and_pbr_shader_options_bind_group,
                 bones_and_pbr_instances_bind_group,
                 bones_and_unlit_instances_bind_group,
                 bones_and_wireframe_instances_bind_group,
@@ -2080,6 +2166,7 @@ impl Renderer {
 
                 point_lights_buffer,
                 directional_lights_buffer,
+                pbr_shader_options_buffer,
                 bones_buffer,
                 pbr_instances_buffer,
                 unlit_instances_buffer,
@@ -2912,6 +2999,17 @@ impl Renderer {
                 &game_state.directional_lights,
             )),
         );
+        queue.write_buffer(
+            &private_data.pbr_shader_options_buffer,
+            0,
+            bytemuck::cast_slice(&[make_pbr_shader_options_uniform_buffer(
+                data.enable_soft_shadows,
+                data.shadow_bias,
+                data.soft_shadow_factor,
+                data.enable_shadow_debug,
+                data.soft_shadow_grid_dims,
+            )]),
+        );
     }
 
     #[profiling::function]
@@ -3116,7 +3214,11 @@ impl Renderer {
                     bytemuck::cast_slice(&[MeshShaderCameraRaw::from(main_camera_data)]),
                 );
 
-                render_pass.set_bind_group(0, &private_data.lights_bind_group, &[]);
+                render_pass.set_bind_group(
+                    0,
+                    &private_data.lights_and_pbr_shader_options_bind_group,
+                    &[],
+                );
                 for unlit_instance_chunk in private_data.all_unlit_instances.chunks() {
                     let binded_unlit_mesh_index = unlit_instance_chunk.id;
                     let instances_buffer_start_index = unlit_instance_chunk.start_index as u32;
@@ -3281,7 +3383,7 @@ impl Renderer {
                     i % 2 == 0,
                 );
             });
-        } else {
+        } else if !private_data.bloom_threshold_cleared {
             // clear bloom texture
             let label = "Bloom clear";
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -3447,7 +3549,11 @@ impl Renderer {
                     0,
                     bytemuck::cast_slice(&[MeshShaderCameraRaw::from(camera)]),
                 );
-                render_pass.set_bind_group(0, &private_data.lights_bind_group, &[]);
+                render_pass.set_bind_group(
+                    0,
+                    &private_data.lights_and_pbr_shader_options_bind_group,
+                    &[],
+                );
                 if !is_shadow {
                     render_pass.set_bind_group(
                         1,

--- a/src/scene_tree.rs
+++ b/src/scene_tree.rs
@@ -133,8 +133,8 @@ impl SceneTree {
                 || child_aabb.fully_contains_sphere(node_bounding_sphere)
             {
                 let distance2 =
-                    (child_aabb.origin() - node_bounding_sphere.origin).length_squared();
-                // pick the aabb whose origin is closest to the object
+                    (child_aabb.center() - node_bounding_sphere.center).length_squared();
+                // pick the aabb whose center is closest to the object
                 fully_contained_index = match fully_contained_index {
                     Some((other_i, other_dist2)) => Some(if distance2 < other_dist2 {
                         (i, distance2)

--- a/src/shaders/textured_mesh.wgsl
+++ b/src/shaders/textured_mesh.wgsl
@@ -43,11 +43,20 @@ struct BonesUniform {
 struct InstancesUniform {
     value: array<Instance>,
 }
+// scratch board for shader options
+struct PbrShaderOptionsUniform {
+    options_1: vec4<f32>,
+    options_2: vec4<f32>,
+    options_3: vec4<f32>,
+    options_4: vec4<f32>,
+}
 
 @group(0) @binding(0)
 var<uniform> point_lights: PointLightsUniform;
 @group(0) @binding(1)
 var<uniform> directional_lights: DirectionalLightsUniform;
+@group(0) @binding(2)
+var<uniform> shader_options: PbrShaderOptionsUniform;
 
 @group(2) @binding(0)
 var<storage, read> bones_uniform: BonesUniform;
@@ -101,6 +110,26 @@ struct ShadowMappingVertexOutput {
 
 struct ShadowMappingFragmentOutput {
     @builtin(frag_depth) depth: f32,
+}
+
+fn get_soft_shadows_are_enabled() -> bool {
+    return shader_options.options_1[0] > 0.0;
+}
+
+fn get_soft_shadow_factor() -> f32 {
+    return shader_options.options_1[1];
+}
+
+fn get_shadow_debug_enabled() -> bool {
+    return shader_options.options_1[2] > 0.0;
+}
+
+fn get_soft_shadow_grid_dims() -> u32 {
+    return u32(shader_options.options_1[3]);
+}
+
+fn get_shadow_bias() -> f32 {
+     return shader_options.options_2[0];
 }
 
 fn do_vertex_shade(
@@ -366,13 +395,63 @@ fn world_normal_to_cubemap_vec(world_pos: vec3<f32>) -> vec3<f32> {
     return vec3<f32>(-world_pos.x, world_pos.y, world_pos.z);
 }
 
-fn rand(co: vec2<f32>) -> f32 {
-    let a = 12.9898;
-    let b = 78.233;
-    let c = 43758.5453;
-    let dt = dot(co, vec2<f32>(a, b));
-    let sn = dt % 3.14;
-    return fract(sin(sn) * c);
+// noise functions from:
+// https://gist.github.com/munrocket/236ed5ba7e409b8bdf1ff6eca5dcdc39
+fn mod289(x: vec4<f32>) -> vec4<f32> { return x - floor(x * (1. / 289.)) * 289.; }
+fn perm4(x: vec4<f32>) -> vec4<f32> { return mod289(((x * 34.) + 1.) * x); }
+
+fn noise3(p: vec3<f32>) -> f32 {
+  let a = floor(p);
+  var d: vec3<f32> = p - a;
+  d = d * d * (3. - 2. * d);
+
+  let b = a.xxyy + vec4<f32>(0., 1., 0., 1.);
+  let k1 = perm4(b.xyxy);
+  let k2 = perm4(k1.xyxy + b.zzww);
+
+  let c = k2 + a.zzzz;
+  let k3 = perm4(c);
+  let k4 = perm4(c + 1.);
+
+  let o1 = fract(k3 * (1. / 41.));
+  let o2 = fract(k4 * (1. / 41.));
+
+  let o3 = o2 * d.z + o1 * (1. - d.z);
+  let o4 = o3.yw * d.x + o3.xz * (1. - d.x);
+
+  return o4.y * d.y + o4.x * (1. - d.y);
+}
+
+fn rand(n: f32) -> f32 { return fract(n * n * 43758.5453123); }
+fn noise(p: f32) -> f32 {
+  let fl = floor(p);
+  let fc = fract(p);
+  return mix(rand(fl), rand(fl + 1.), fc);
+}
+
+fn disk_warp(coord: vec2<f32>) -> vec2<f32> {
+    let warped = vec2<f32>(
+        sqrt(coord.y) * cos(2.0 * pi * coord.x),
+        sqrt(coord.y) * sin(2.0 * pi * coord.x)
+    );
+    return vec2<f32>(0.5, 0.5) * warped + vec2<f32>(0.5, 0.5);
+}
+
+// see https://developer.nvidia.com/gpugems/gpugems2/part-ii-shading-lighting-and-shadows/chapter-17-efficient-soft-edged-shadows-using
+// and https://www.shadertoy.com/view/dtd3Dr
+// jitter_amount values have domain of (-1, 1)
+fn get_soft_shadow_sample_jitter(grid_coord: vec2<u32>, jitter_amount: vec2<f32>, grid_dims: u32) -> vec2<f32> {
+    // (0, 1) domain
+    let cell_size = 1.0 / f32(grid_dims);
+    let cell_top_left = vec2<f32>(f32(grid_coord.x), f32(grid_coord.y)) * vec2<f32>(cell_size, cell_size);
+    let cell_center = cell_top_left + vec2<f32>(0.5 * cell_size);
+
+    // jitter from the default center positions
+    let max_jitter = 0.5 * cell_size;
+    let jittered_cell_center = cell_center + vec2<f32>(max_jitter, max_jitter) * jitter_amount;
+    
+    // convert to (-1, 1) domain
+    return vec2(2.0, 2.0) * disk_warp(jittered_cell_center) - vec2(1.0, 1.0);
 }
 
 fn compute_direct_lighting(
@@ -442,6 +521,7 @@ fn do_fragment_shade(
         diffuse_sampler,
         tex_coords
     );
+    
     let base_color = base_color_t.rgb * base_color_factor.rgb * vertex_color.rgb;
     let metallic_roughness = textureSample(
         metallic_roughness_map_texture,
@@ -489,11 +569,15 @@ fn do_fragment_shade(
     let brdf_lut_res = textureSample(brdf_lut_texture, brdf_lut_sampler, vec2<f32>(n_dot_v, roughness));
     let env_map_diffuse_irradiance = textureSample(diffuse_env_map_texture, diffuse_env_map_sampler, world_normal_to_cubemap_vec(world_normal)).rgb;
 
-
-    let random_seed = vec2<f32>(
-        round(100000.0 * (world_position.x + world_position.y)),
-        round(100000.0 * (world_position.y + world_position.z)),
+    var random_seed_x = 1000.0 * vec3<f32>(
+        world_position.x,
+        world_position.y,
+        world_position.z,
     );
+
+    var random_seed_y = random_seed_x + 1000.0;
+
+    var random_jitter = vec2(2.0, 2.0) * vec2(noise3(random_seed_x), noise3(random_seed_y)) - vec2(1.0, 1.0);
 
     var total_light_irradiance = vec3<f32>(0.0);
     for (var light_index = 0u; light_index < MAX_LIGHTS; light_index = light_index + 1u) {
@@ -501,7 +585,7 @@ fn do_fragment_shade(
         let light_color_scaled = light.color.xyz * light.color.w;
 
         if light_color_scaled.x < epsilon && light_color_scaled.y < epsilon && light_color_scaled.z < epsilon {
-            continue;
+            break;
         }
 
         let from_shadow_vec = world_position - light.position.xyz;
@@ -511,32 +595,32 @@ fn do_fragment_shade(
 
         // soft shadows
         // irregular shadow sampling
-        var shadow_occlusion_acc = 0.0;
-        let sample_count = 4.0;
-        let max_offset_x = 0.01 + 0.04 * rand(random_seed * 1.0);
-        let max_offset_y = 0.01 + 0.04 * rand(random_seed * 2.0);
-        let max_offset_z = 0.01 + 0.04 * rand(random_seed * 3.0);
-        for (var x = 0.0; x < sample_count; x = x + 1.0) {
-            for (var y = 0.0; y < sample_count; y = y + 1.0) {
-                for (var z = 0.0; z < sample_count; z = z + 1.0) {
-                    let irregular_offset = vec3<f32>(
-                        max_offset_x * ((2.0 * x / (sample_count - 1.0)) - 1.0),
-                        max_offset_y * ((2.0 * y / (sample_count - 1.0)) - 1.0),
-                        max_offset_z * ((2.0 * z / (sample_count - 1.0)) - 1.0),
-                    );
-                    let closest_depth = textureSample(
-                        point_shadow_map_textures,
-                        point_shadow_map_sampler,
-                        world_normal_to_cubemap_vec(from_shadow_vec + irregular_offset),
-                        i32(light_index)
-                    ).r;
-                    if current_depth - bias < closest_depth {
-                        shadow_occlusion_acc = shadow_occlusion_acc + 1.0;
-                    }
-                }
-            }
-        }
-        let shadow_occlusion_factor = shadow_occlusion_acc / (sample_count * sample_count * sample_count);
+        // var shadow_occlusion_acc = 0.0;
+        // let sample_count = 4.0;
+        // let max_offset_x = 0.01 + 0.04 * rand(random_seed * 1.0);
+        // let max_offset_y = 0.01 + 0.04 * rand(random_seed * 2.0);
+        // let max_offset_z = 0.01 + 0.04 * rand(random_seed * 3.0);
+        // for (var x = 0.0; x < sample_count; x = x + 1.0) {
+        //     for (var y = 0.0; y < sample_count; y = y + 1.0) {
+        //         for (var z = 0.0; z < sample_count; z = z + 1.0) {
+        //             let irregular_offset = vec3<f32>(
+        //                 max_offset_x * ((2.0 * x / (sample_count - 1.0)) - 1.0),
+        //                 max_offset_y * ((2.0 * y / (sample_count - 1.0)) - 1.0),
+        //                 max_offset_z * ((2.0 * z / (sample_count - 1.0)) - 1.0),
+        //             );
+        //             let closest_depth = textureSample(
+        //                 point_shadow_map_textures,
+        //                 point_shadow_map_sampler,
+        //                 world_normal_to_cubemap_vec(from_shadow_vec + irregular_offset),
+        //                 i32(light_index)
+        //             ).r;
+        //             if current_depth - bias < closest_depth {
+        //                 shadow_occlusion_acc = shadow_occlusion_acc + 1.0;
+        //             }
+        //         }
+        //     }
+        // }
+        // let shadow_occlusion_factor = shadow_occlusion_acc / (sample_count * sample_count * sample_count);
 
         // regular shadow sampling
         // var shadow_occlusion_acc = 0.0;
@@ -574,13 +658,12 @@ fn do_fragment_shade(
         //     shadow_occlusion_factor = 1.0;
         // }
 
-        if shadow_occlusion_factor < epsilon {
-                continue;
-        }
+        // if shadow_occlusion_factor < epsilon {
+        //         continue;
+        // }
 
         let to_light_vec = light.position.xyz - world_position;
         let to_light_vec_norm = normalize(to_light_vec);
-
         let distance_from_light = length(to_light_vec);
         // https://learnopengl.com/Lighting/Light-casters
         // let light_attenuation_factor_d20 = 1.0 / (1.0 + 0.22 * distance_from_light + 0.20 * distance_from_light * distance_from_light);
@@ -600,15 +683,21 @@ fn do_fragment_shade(
             metallicness,
             f0
         );
-        total_light_irradiance = total_light_irradiance + light_irradiance * shadow_occlusion_factor;
+        total_light_irradiance = total_light_irradiance + light_irradiance;
     }
+
+    var total_shadow_occlusion_acc = 0.0;
+    var total_directional_light_count = 0u;
+
+    let soft_shadow_grid_dims = get_soft_shadow_grid_dims();
 
     for (var light_index = 0u; light_index < MAX_LIGHTS; light_index = light_index + 1u) {
         let light = directional_lights.values[light_index];
         let light_color_scaled = light.color.xyz * light.color.w;
 
         if light_color_scaled.x < epsilon && light_color_scaled.y < epsilon && light_color_scaled.z < epsilon {
-            continue;
+            // TODO: does break here help improve performance a lot compared to continue?;
+            break;
         }
 
         // let from_shadow_vec = world_position - light.position.xyz;
@@ -620,62 +709,109 @@ fn do_fragment_shade(
             light_space_position.x * 0.5 + 0.5,
             1.0 - (light_space_position.y * 0.5 + 0.5),
         );
-        let current_depth = light_space_position.z;
-        let bias = 0.0001;
+        let current_depth = light_space_position.z; // domain is (0, 1), lower means closer to the light
+        let bias = get_shadow_bias();
+        let to_light_vec = light.position.xyz - world_position;
+        let to_light_vec_norm = normalize(to_light_vec);
+        let n_dot_l = max(dot(n, to_light_vec_norm), 0.0);
 
         // soft shadows
         var shadow_occlusion_acc = 0.0;
-        let sample_count = 4.0;
-        let max_offset_x = 0.0001 + 0.0005 * rand(random_seed * 1.0);
-        let max_offset_y = 0.0001 + 0.0005 * rand(random_seed * 2.0);
-        for (var x = 0.0; x < sample_count; x = x + 1.0) {
-            for (var y = 0.0; y < sample_count; y = y + 1.0) {
-                let irregular_offset = vec2<f32>(
-                    max_offset_x * ((2.0 * x / (sample_count - 1.0)) - 1.0),
-                    max_offset_y * ((2.0 * y / (sample_count - 1.0)) - 1.0)
+
+        if light_space_position.x >= -1.0 && light_space_position.x <= 1.0 && light_space_position.y >= -1.0 && light_space_position.y <= 1.0 && light_space_position.z >= 0.0 && light_space_position.z <= 1.0 {
+            if get_soft_shadows_are_enabled() {
+                // soft shadows code path. costs about 0.15ms (per shadow map?) per frame on an RTX 3060
+
+                // these coordinates will distribute the early samples
+                // around the edges of the soft shadow poisson sampling disc
+                var early_test_coords = array<vec2<u32>, 4>(
+                    vec2<u32>(0u, 3u),
+                    vec2<u32>(1u, 3u),
+                    vec2<u32>(2u, 3u),
+                    vec2<u32>(3u, 3u)
                 );
-                let closest_depth = textureSample(
+
+                let max_sample_jitter = get_soft_shadow_factor();
+
+                for (var i = 0; i < 4; i++) {
+                    let base_sample_jitter = get_soft_shadow_sample_jitter(early_test_coords[i], random_jitter, 4u);
+                    // TODO: multiply by current_depth to get softer shadows at a distance?
+                    let sample_jitter = base_sample_jitter * max_sample_jitter;
+                    let closest_depth = textureSampleLevel(
+                        directional_shadow_map_textures,
+                        directional_shadow_map_sampler,
+                        light_space_position_uv + sample_jitter,
+                        i32(light_index),
+                        0.0
+                    ).r;
+
+                    if current_depth - bias < closest_depth {
+                        shadow_occlusion_acc = shadow_occlusion_acc + 0.25;
+                    }
+                }
+
+                // if the early test finds the fragment to be completely in shadow, 
+                // completely in light, or its surface isn't facing the light (n_dot_l =< 0)
+                // then skip the extra work that we do to soften the penumbra
+                if (shadow_occlusion_acc - 1.0) * shadow_occlusion_acc * n_dot_l != 0.0 {
+                    
+                    if soft_shadow_grid_dims > 0u {
+                        // TODO: don't clear shadow_occlusion_acc, we can perserve it and perform fewer samples here
+                        // (skip the samples already done by early test) for a theoretically equivalent level of quality
+                        // and decent performance boost if soft_shadow_grid_dims isn't too high
+                        shadow_occlusion_acc = 0.0;
+                    }
+
+                    for (var i = 0u; i < soft_shadow_grid_dims; i++) {
+                        for (var j = 0u; j < soft_shadow_grid_dims; j++) {
+                            let coord = vec2<u32>(i, j);
+                            let base_sample_jitter = get_soft_shadow_sample_jitter(coord, random_jitter, soft_shadow_grid_dims);
+                            // TODO: multiply by current_depth to get softer shadows at a distance?
+                            let sample_jitter = base_sample_jitter * max_sample_jitter;
+                            let closest_depth = textureSampleLevel(
+                                directional_shadow_map_textures,
+                                directional_shadow_map_sampler,
+                                light_space_position_uv + sample_jitter,
+                                i32(light_index),
+                                0.0
+                            ).r;
+                            
+                            if current_depth - bias < closest_depth {
+                                shadow_occlusion_acc = shadow_occlusion_acc + (1.0 / f32(soft_shadow_grid_dims * soft_shadow_grid_dims));
+                            }
+                        }
+                    }
+                }
+            } else {
+                // hard shadows
+                let closest_depth = textureSampleLevel(
                     directional_shadow_map_textures,
                     directional_shadow_map_sampler,
-                    light_space_position_uv + irregular_offset,
-                    i32(light_index)
+                    light_space_position_uv,
+                    i32(light_index),
+                    0.0
                 ).r;
                 if light_space_position.x >= -1.0 && light_space_position.x <= 1.0 && light_space_position.y >= -1.0 && light_space_position.y <= 1.0 && light_space_position.z >= 0.0 && light_space_position.z <= 1.0 {
                     if current_depth - bias < closest_depth {
-                        shadow_occlusion_acc = shadow_occlusion_acc + 1.0;
+                        shadow_occlusion_acc = 1.0;
                     }
                 } else {
-                    shadow_occlusion_acc = shadow_occlusion_acc + 1.0;
+                    shadow_occlusion_acc = 1.0;
                 }
             }
         }
-        let shadow_occlusion_factor = shadow_occlusion_acc / (sample_count * sample_count);
-
-        // hard shadows
-        // var shadow_occlusion_factor = 1.0;
-        // let closest_depth = textureSample(
-        //     directional_shadow_map_textures,
-        //     directional_shadow_map_sampler,
-        //     light_space_position_uv,
-        //     i32(light_index)
-        // ).r;
-        // if (light_space_position.x >= -1.0 && light_space_position.x <= 1.0 && light_space_position.y >= -1.0 && light_space_position.y <= 1.0 && light_space_position.z >= 0.0 && light_space_position.z <= 1.0) {
-        //     if (current_depth - bias < closest_depth) {
-        //         shadow_occlusion_factor = 1.0;
-        //     }
-        // } else {
-        //     shadow_occlusion_factor = 1.0;
-        // }
-
+        
+        var shadow_occlusion_factor = shadow_occlusion_acc;
+        total_shadow_occlusion_acc = total_shadow_occlusion_acc + shadow_occlusion_acc;
+        total_directional_light_count = total_directional_light_count + 1u;
 
         if shadow_occlusion_factor < epsilon {
                 continue;
         }
 
-        let to_light_vec = -light.direction.xyz;
-        let to_light_vec_norm = normalize(to_light_vec);
         let light_attenuation_factor = 1.0;
 
+        // TODO: accumulate total shadow occlusion amount and average light color and only call compute_direct_lighting once?
         let light_irradiance = compute_direct_lighting(
             world_normal,
             to_viewer_vec,
@@ -690,9 +826,12 @@ fn do_fragment_shade(
         total_light_irradiance = total_light_irradiance + light_irradiance * shadow_occlusion_factor;
     }
 
-
-
-
+    if get_shadow_debug_enabled() {
+        total_shadow_occlusion_acc = total_shadow_occlusion_acc / f32(total_directional_light_count);
+        var out: FragmentOutput;
+        out.color = vec4<f32>(total_shadow_occlusion_acc, total_shadow_occlusion_acc, total_shadow_occlusion_acc, 1.0);
+        return out;
+    }
 
     let fresnel_ambient = fresnel_func_schlick_with_roughness(n_dot_v, f0, a);
     // mip level count - 1

--- a/src/shaders/textured_mesh.wgsl
+++ b/src/shaders/textured_mesh.wgsl
@@ -28,7 +28,7 @@ struct Instance {
     base_color_factor: vec4<f32>,
     emissive_factor: vec4<f32>,
     mrno: vec4<f32>, // metallicness_factor, roughness_factor, normal scale, occlusion strength
-    alpha_cutoff: vec4<f32>,
+    alpha_cutoff: vec4<f32>, // alpha_cutoff, culling_mask, padding
 }
 
 struct PointLightsUniform {

--- a/src/shaders/textured_mesh.wgsl
+++ b/src/shaders/textured_mesh.wgsl
@@ -687,7 +687,6 @@ fn do_fragment_shade(
         let light_space_position_face_slice = light_space_position_uv_and_face_slice.z;
         let shadow_camera_far_plane_distance = 1000.0;
         let current_depth = length(from_shadow_vec) / shadow_camera_far_plane_distance; // domain is (0, 1), lower means closer to the light
-        // let bias = 0.0001;
 
         var shadow_occlusion_acc = 0.0;
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -389,13 +389,13 @@ impl Texture {
 
     pub fn create_depth_texture_array(
         base_renderer: &BaseRenderer,
-        size: u32,
+        size: (u32, u32),
         label: Option<&str>,
         length: u32,
     ) -> Self {
         let size = wgpu::Extent3d {
-            width: size,
-            height: size,
+            width: size.0,
+            height: size.1,
             depth_or_array_layers: length,
         };
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -425,9 +425,9 @@ impl Texture {
             .get_sampler_index(
                 &base_renderer.device,
                 &SamplerDescriptor {
-                    address_mode_u: wgpu::AddressMode::Repeat,
-                    address_mode_v: wgpu::AddressMode::Repeat,
-                    address_mode_w: wgpu::AddressMode::Repeat,
+                    address_mode_u: wgpu::AddressMode::ClampToEdge,
+                    address_mode_v: wgpu::AddressMode::ClampToEdge,
+                    address_mode_w: wgpu::AddressMode::ClampToEdge,
                     mag_filter: wgpu::FilterMode::Nearest,
                     min_filter: wgpu::FilterMode::Nearest,
                     mipmap_filter: wgpu::FilterMode::Nearest,


### PR DESCRIPTION
resolves #47 
resolves #37

- add a bunch of new debug overlays and texts, controllable through options menu
- show breakdown of different render passes in performance stats overlay
- various performance improvements
- support transparency and use it for debug overlays now instead of wireframe
- frustum culling improvements
  - fix bug where frustum culling caused shadow pop-in
  - add debug tools
  - improve culling results with frustum-sphere test instead of frustum-aabb
- rework soft shadows implementation based off of this article: https://developer.nvidia.com/gpugems/gpugems2/part-ii-shading-lighting-and-shadows/chapter-17-efficient-soft-edged-shadows-using
  - shadows are much faster now
  - add a bunch of configurable properties for shadows (bias, softness, soft tap count)
  - adapt implementation to work with point light shadow maps too
    - use texture atlas instead of cube texture
    - 