### PR TITLE
Audio streaming

### DIFF
--- a/src/asset_loader.rs
+++ b/src/asset_loader.rs
@@ -92,12 +92,16 @@ impl AssetLoader {
 
                     let do_load = || {
                         let device_sample_rate = audio_manager.lock().unwrap().device_sample_rate();
-                        let sound_data = AudioManager::decode_audio_file(
+                        let mut audio_file_streamer = AudioFileStreamer::new(
                             device_sample_rate,
-                            &next_audio_path,
+                            next_audio_path.clone(),
                             Some(next_audio_format),
                         )?;
-                        // let sound = Sound::new(self, sound_data, params);
+                        let sound_data = if !next_audio_params.stream {
+                            audio_file_streamer.read_chunk(0)?.0
+                        } else {
+                            Default::default()
+                        };
                         let signal = AudioManager::get_signal(
                             &sound_data,
                             next_audio_params.clone(),
@@ -105,9 +109,18 @@ impl AssetLoader {
                         );
                         let sound_index = audio_manager.lock().unwrap().add_sound(
                             sound_data,
-                            next_audio_params,
+                            next_audio_params.clone(),
                             signal,
                         );
+
+                        if next_audio_params.stream {
+                            Self::spawn_audio_streaming_thread(
+                                audio_manager.clone(),
+                                sound_index,
+                                audio_file_streamer,
+                            );
+                        }
+
                         anyhow::Ok(sound_index)
                     };
                     match do_load() {
@@ -127,5 +140,57 @@ impl AssetLoader {
                 }
             });
         }
+    }
+
+    fn spawn_audio_streaming_thread(
+        audio_manager: Arc<Mutex<AudioManager>>,
+        sound_index: usize,
+        mut audio_file_streamer: AudioFileStreamer,
+    ) {
+        let device_sample_rate = audio_manager.lock().unwrap().device_sample_rate();
+        let mut is_first_chunk = true;
+        std::thread::spawn(move || loop {
+            let chunk_size_seconds = if is_first_chunk {
+                AUDIO_STREAM_BUFFER_LENGTH_SECONDS * 0.75
+            } else {
+                AUDIO_STREAM_BUFFER_LENGTH_SECONDS * 0.5
+            };
+            is_first_chunk = false;
+            match audio_file_streamer
+                .read_chunk((device_sample_rate as f32 * chunk_size_seconds) as usize)
+            {
+                Ok((sound_data, reached_end_of_stream)) => {
+                    let sample_count = sound_data.0.len();
+                    audio_manager
+                        .lock()
+                        .unwrap()
+                        .write_stream_data(sound_index, sound_data);
+                    // logger_log(&format!(
+                    //     "Streamed in {:?} samples ({:?} seconds) from file: {}",
+                    //     sample_count,
+                    //     sample_count as f32 / device_sample_rate as f32,
+                    //     audio_file_streamer.file_path(),
+                    // ));
+                    if reached_end_of_stream {
+                        logger_log(&format!(
+                            "Reached end of stream for file: {}",
+                            audio_file_streamer.file_path(),
+                        ));
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_secs_f32(
+                        AUDIO_STREAM_BUFFER_LENGTH_SECONDS * 0.5,
+                    ));
+                }
+                Err(err) => {
+                    logger_log(&format!(
+                        "Error loading audio asset {}: {}\n{}",
+                        audio_file_streamer.file_path(),
+                        err,
+                        err.backtrace()
+                    ));
+                }
+            }
+        });
     }
 }

--- a/src/asset_loader.rs
+++ b/src/asset_loader.rs
@@ -160,7 +160,7 @@ impl AssetLoader {
                 .read_chunk((device_sample_rate as f32 * chunk_size_seconds) as usize)
             {
                 Ok((sound_data, reached_end_of_stream)) => {
-                    let sample_count = sound_data.0.len();
+                    // let sample_count = sound_data.0.len();
                     audio_manager
                         .lock()
                         .unwrap()

--- a/src/game.rs
+++ b/src/game.rs
@@ -186,6 +186,7 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
                 initial_volume: 0.5,
                 fixed_volume: false,
                 spacial_params: None,
+                stream: true,
             },
         );
         asset_loader.load_audio(
@@ -195,6 +196,7 @@ pub fn init_game_state(mut scene: Scene, renderer: &mut Renderer) -> Result<Game
                 initial_volume: 0.75,
                 fixed_volume: true,
                 spacial_params: None,
+                stream: false,
             },
         );
     });
@@ -1507,6 +1509,7 @@ pub fn update_game_state(
                             initial_volume: 0.75,
                             fixed_volume: true,
                             spacial_params: None,
+                            stream: false,
                         },
                     )
                 }


### PR DESCRIPTION
Reduces memory overhead by streaming background music with a buffer of ~2 seconds per song instead of buffering the entire song 