### PR TITLE
Fix web mouse capture

### DIFF
--- a/build-web/src/main.rs
+++ b/build-web/src/main.rs
@@ -285,5 +285,3 @@ fn main() {
             });
     }
 }
-
-// async fn run_server(port: u16, root: PathBuf) {}

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -887,7 +887,7 @@ impl Renderer {
         vec![
             "Look Around:             Mouse",
             "Move Around:             WASD, Space Bar, Ctrl",
-            "Adjust Speed:            Scroll",
+            "Adjust Speed:            Scroll or Up/Down Arrow Keys",
             "Adjust Render Scale:     Z / X",
             "Adjust Exposure:         E / R",
             "Adjust Bloom Threshold:  T / Y",
@@ -897,7 +897,7 @@ impl Renderer {
             "Toggle Wireframe:        F",
             "Toggle Collision Boxes:  C",
             "Draw Bounding Spheres:   J",
-            "Open Options Menu:       Escape",
+            "Open Options Menu:       Tab",
         ]
         .iter()
         .for_each(|line| {


### PR DESCRIPTION
 - rebind escape to ctrl for pause menu, prevents issue with browser using the escape key to give mouse control back to the user
  - add arrow up/down keys option for adjusting speed to account for fact that winit doesn't support mouse scrollwheel yet