### PR TITLE
inline frustum_intersection_test function to prevent accidental perf footgun

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ opt-level = 3
 [profile.dev.package."wgpu-core"]
 debug-assertions = false
 
+[profile.dev.package."wgpu-types"]
+debug-assertions = false
+
 # [profile.dev.package."wgpu"]
 # debug-assertions = false
 

--- a/ikari/src/collisions.rs
+++ b/ikari/src/collisions.rs
@@ -369,17 +369,7 @@ impl From<CameraFrustumDescriptor> for Frustum {
 }
 
 impl CameraFrustumDescriptor {
-    // TODO: this function is slow due to the calls to to_convex_polyhedron. should cache the convex polyhedra.
-    pub fn frustum_intersection_test(&self, other: &CameraFrustumDescriptor) -> bool {
-        rapier3d_f64::parry::query::intersection_test(
-            &rapier3d_f64::na::Isometry::identity(),
-            &self.to_convex_polyhedron(),
-            &rapier3d_f64::na::Isometry::identity(),
-            &other.to_convex_polyhedron(),
-        )
-        .unwrap()
-    }
-
+    /// this is not free. consider caching the result
     pub fn to_convex_polyhedron(&self) -> ConvexPolyhedron {
         let points: Vec<_> = self
             .to_basic_mesh()

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -3334,8 +3334,14 @@ impl Renderer {
                     };
                     let debug_culling_frustum_mesh = debug_frustum_descriptor.to_basic_mesh();
 
-                    let collision_based_color = if frustum_descriptor
-                        .frustum_intersection_test(main_culling_frustum_desc)
+                    let identity = rapier3d_f64::na::Isometry::identity();
+                    let collision_based_color = if rapier3d_f64::parry::query::intersection_test(
+                        &identity,
+                        &frustum_descriptor.to_convex_polyhedron(),
+                        &identity,
+                        &main_culling_frustum_desc.to_convex_polyhedron(),
+                    )
+                    .unwrap()
                     {
                         Vec4::new(0.0, 1.0, 0.0, 0.1)
                     } else {
@@ -4038,7 +4044,13 @@ impl Renderer {
                                     // that are inside the main view so we can completely skip the shadow map
                                     // render pass for this light view
                                     let is_light_view_culled = if USE_EXTRA_SHADOW_MAP_CULLING {
-                                        !desc.frustum_intersection_test(&culling_frustum_desc)
+                                        !rapier3d_f64::parry::query::intersection_test(
+                                            &rapier3d_f64::na::Isometry::identity(),
+                                            &desc.to_convex_polyhedron(),
+                                            &rapier3d_f64::na::Isometry::identity(),
+                                            &culling_frustum_desc.to_convex_polyhedron(),
+                                        )
+                                        .unwrap()
                                     } else {
                                         false
                                     };


### PR DESCRIPTION
and disable debug-assertions in wgpu-types to prevent validation layers from being enable since https://github.com/gfx-rs/wgpu/pull/4230