### PR TITLE
Render only one shadow map pass per point light

### DIFF
--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -401,12 +401,12 @@ pub async fn init_game_state(
                 ..Default::default()
             },
         },
-        DirectionalLight {
-            direction: (-Vec3::new(1.0, 5.0, -10.0)).normalize(),
-            color: _DIRECTIONAL_LIGHT_COLOR_A,
-            intensity: 1.0,
-            shadow_mapping_config: Default::default(),
-        },
+        // DirectionalLight {
+        //     direction: (-Vec3::new(1.0, 5.0, -10.0)).normalize(),
+        //     color: _DIRECTIONAL_LIGHT_COLOR_A,
+        //     intensity: 1.0,
+        //     shadow_mapping_config: Default::default(),
+        // },
         // DirectionalLight {
         //     direction: (-Vec3::new(10.0, 10.0, 1.0)).normalize(),
         //     color: DIRECTIONAL_LIGHT_COLOR_B,

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -64,7 +64,7 @@ use winit::keyboard::Key;
 use winit::keyboard::NamedKey;
 
 // graphics settings
-pub const INITIAL_ENABLE_VSYNC: bool = true;
+pub const INITIAL_ENABLE_VSYNC: bool = false;
 pub const INITIAL_ENABLE_DEPTH_PREPASS: bool = false;
 pub const INITIAL_ENABLE_SHADOWS: bool = true;
 pub const INITIAL_ENABLE_DIRECTIONAL_SHADOW_CULLING: bool = true;

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -390,12 +390,6 @@ pub async fn init_game_state(
 
     // add lights to the scene
     engine_state.scene.directional_lights = vec![
-        // DirectionalLight {
-        //     direction: (-Vec3::new(1.0, 5.0, -10.0)).normalize(),
-        //     color: _DIRECTIONAL_LIGHT_COLOR_A,
-        //     intensity: 1.0,
-        //     shadow_mapping_config: Default::default(),
-        // },
         DirectionalLight {
             direction: (-Vec3::new(-1.0, 10.0, 10.0)).normalize(),
             color: DIRECTIONAL_LIGHT_COLOR_B,
@@ -406,6 +400,12 @@ pub async fn init_game_state(
                 // first_cascade_far_bound: 10.0,
                 ..Default::default()
             },
+        },
+        DirectionalLight {
+            direction: (-Vec3::new(1.0, 5.0, -10.0)).normalize(),
+            color: _DIRECTIONAL_LIGHT_COLOR_A,
+            intensity: 1.0,
+            shadow_mapping_config: Default::default(),
         },
         // DirectionalLight {
         //     direction: (-Vec3::new(10.0, 10.0, 1.0)).normalize(),

--- a/example_game/src/main.rs
+++ b/example_game/src/main.rs
@@ -74,7 +74,7 @@ async fn start() {
 
         let (base_renderer, mut surface_data) = {
             let backends = if cfg!(target_os = "windows") {
-                wgpu::Backends::from(wgpu::Backend::Dx12)
+                wgpu::Backends::from(wgpu::Backend::Vulkan)
                 // wgpu::Backends::PRIMARY
             } else {
                 wgpu::Backends::PRIMARY

--- a/ikari/src/shaders/textured_mesh.wgsl
+++ b/ikari/src/shaders/textured_mesh.wgsl
@@ -878,16 +878,14 @@ fn do_fragment_shade(
         if n_dot_l > 0.0 {
             if light_index < DIRECTIONAL_LIGHT_SHOW_MAP_COUNT {
 
-                var shadow_cascade_index = light_index;
+                var shadow_cascade_index = light_index * MAX_SHADOW_CASCADES;
                 var shadow_cascade_dist = 0.0;
 
                 // dist = directional_lights.cascades[light_index * MAX_SHADOW_CASCADES].distance.x;
                 for (var cascade_index = 0u; cascade_index < MAX_SHADOW_CASCADES; cascade_index = cascade_index + 1u) {
-                    shadow_cascade_dist = directional_lights.cascades[light_index * MAX_SHADOW_CASCADES + cascade_index].distance_and_pixel_size.x;
-                    debug_cascade_index = i32(shadow_cascade_index);
+                    shadow_cascade_dist = directional_lights.cascades[shadow_cascade_index].distance_and_pixel_size.x;
                     if shadow_cascade_dist == 0.0 || 
                         to_viewer_vec_length < shadow_cascade_dist {
-
                         if (shadow_cascade_dist == 0.0) {
                             debug_cascade_index = -1;
                         }
@@ -895,6 +893,7 @@ fn do_fragment_shade(
                         break;
                     }
                     shadow_cascade_index = shadow_cascade_index + 1u;
+                    debug_cascade_index = debug_cascade_index + 1;
                 }
 
                 let shadow_cascade_pixel_size = directional_lights.cascades[shadow_cascade_index].distance_and_pixel_size.y;
@@ -931,7 +930,7 @@ fn do_fragment_shade(
                                 directional_shadow_map_textures,
                                 shadow_map_sampler,
                                 light_space_position_uv + sample_jitter,
-                                i32(light_index + shadow_cascade_index),
+                                i32(shadow_cascade_index),
                                 0.0
                             ).r;
 
@@ -964,7 +963,7 @@ fn do_fragment_shade(
                                         directional_shadow_map_textures,
                                         shadow_map_sampler,
                                         light_space_position_uv + sample_jitter,
-                                        i32(light_index + shadow_cascade_index),
+                                        i32(shadow_cascade_index),
                                         0.0
                                     ).r;
                                     
@@ -980,7 +979,7 @@ fn do_fragment_shade(
                             directional_shadow_map_textures,
                             shadow_map_sampler,
                             light_space_position_uv,
-                            i32(light_index + shadow_cascade_index),
+                            i32(shadow_cascade_index),
                             0.0
                         ).r;
                         if current_depth - bias < closest_depth {


### PR DESCRIPTION
Down from 1.23ms to 0.9ms per point light at 1024x1024 resoluion (per point map face)

also fix bug where more than one directional light screws up all cascaded shadows