### PR TITLE
More options improvements + framerate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3075c01f2b1799945892d5310fc1836e47c045dfe6af5878a304a475931a0c5f"
+checksum = "a0d7ef7f2a826d0b19f059035831ce00a5e930435cc53c61e045773d0483f67a"
 dependencies = [
  "glam 0.25.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,4 +72,4 @@ opt-level = 1
 opt-level = 3
 
 [profile.release]
-debug = true
+# debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,4 +72,4 @@ opt-level = 1
 opt-level = 3
 
 [profile.release]
-# debug = true
+debug = true

--- a/README.md
+++ b/README.md
@@ -162,5 +162,6 @@ TRACY_DPI_SCALE=1.0 ./Tracy-release
 
 ```sh
 # this will run clippy on the example game as well as ikari by dependency
-RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --package example_game --target wasm32-unknown-unknown
+# we need to pass --no-default-features now that tracy is enabled by default
+RUSTFLAGS=--cfg=web_sys_unstable_apis cargo clippy --package example_game --target wasm32-unknown-unknown --no-default-features
 ```

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -62,23 +62,32 @@ use winit::event::{ElementState, WindowEvent};
 use winit::keyboard::Key;
 use winit::keyboard::NamedKey;
 
-// graphics settings
-// TODO: replace the ones that are using the defaults with a call to ::default
+// engine settings
 pub const INITIAL_ENABLE_VSYNC: bool = true;
+pub const INITIAL_ENABLE_DEPTH_PREPASS: bool = false;
 pub const INITIAL_FRAMERATE_LIMIT: FramerateLimit = FramerateLimit::None;
+pub const INITIAL_RENDER_SCALE: f32 = 1.0;
+
+pub const INITIAL_FOV_X: f32 = 103.0 * std::f32::consts::PI / 180.0;
 pub const INITIAL_NEAR_PLANE_DISTANCE: f32 = 0.001;
 pub const INITIAL_FAR_PLANE_DISTANCE: f32 = 100000.0;
-pub const INITIAL_FOV_X: f32 = 103.0 * std::f32::consts::PI / 180.0;
-pub const INITIAL_ENABLE_DEPTH_PREPASS: bool = false;
-pub const INITIAL_ENABLE_SHADOWS: bool = true;
-pub const INITIAL_RENDER_SCALE: f32 = 2.0;
+
 pub const INITIAL_TONE_MAPPING_EXPOSURE: f32 = 1.0;
-pub const INITIAL_SHADOW_SMALL_OBJECT_CULLING_SIZE_PIXELS: f32 = 16.0;
+pub const INITIAL_BLOOM_TYPE: BloomType = BloomType::New;
 pub const INITIAL_OLD_BLOOM_THRESHOLD: f32 = 0.8;
 pub const INITIAL_OLD_BLOOM_RAMP_SIZE: f32 = 0.2;
 pub const INITIAL_NEW_BLOOM_RADIUS: f32 = 0.005;
 pub const INITIAL_NEW_BLOOM_INTENSITY: f32 = 0.04;
-pub const INITIAL_BLOOM_TYPE: BloomType = BloomType::New;
+pub const INITIAL_SKYBOX_WEIGHT: f32 = 1.0;
+
+pub const INITIAL_ENABLE_SHADOWS: bool = true;
+pub const INITIAL_ENABLE_SOFT_SHADOWS: bool = true;
+pub const INITIAL_SHADOW_BIAS: f32 = 0.001;
+pub const INITIAL_SOFT_SHADOW_FACTOR: f32 = 0.00003;
+pub const INITIAL_SOFT_SHADOWS_MAX_DISTANCE: f32 = 100.0;
+pub const INITIAL_SOFT_SHADOW_GRID_DIMS: u32 = 4;
+pub const INITIAL_SHADOW_SMALL_OBJECT_CULLING_SIZE_PIXELS: f32 = 16.0;
+
 pub const INITIAL_IS_SHOWING_CAMERA_POSE: bool = false;
 pub const INITIAL_IS_SHOWING_CURSOR_MARKER: bool = false;
 pub const INITIAL_ENABLE_SHADOW_DEBUG: bool = false;
@@ -86,12 +95,6 @@ pub const INITIAL_ENABLE_CASCADE_DEBUG: bool = false;
 pub const INITIAL_ENABLE_CULLING_FRUSTUM_DEBUG: bool = false;
 pub const INITIAL_ENABLE_POINT_LIGHT_CULLING_FRUSTUM_DEBUG: bool = false;
 pub const INITIAL_ENABLE_DIRECTIONAL_LIGHT_CULLING_FRUSTUM_DEBUG: bool = false;
-pub const INITIAL_ENABLE_SOFT_SHADOWS: bool = true;
-pub const INITIAL_SHADOW_BIAS: f32 = 0.001;
-pub const INITIAL_SKYBOX_WEIGHT: f32 = 1.0;
-pub const INITIAL_SOFT_SHADOW_FACTOR: f32 = 0.00003;
-pub const INITIAL_SOFT_SHADOW_GRID_DIMS: u32 = 4;
-pub const INITIAL_SOFT_SHADOWS_MAX_DISTANCE: f32 = 100.0;
 
 // game settings
 pub const ARENA_SIDE_LENGTH: f32 = 500.0;

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -1310,7 +1310,7 @@ pub fn process_device_input(
     game_state.player_controller.process_device_event(event);
 }
 
-pub fn handle_window_resize(
+pub fn handle_surface_resize(
     GameContext {
         game_state, window, ..
     }: GameContext<GameState>,

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -2089,24 +2089,6 @@ pub fn update_game_state(
 
     game_state.ui_overlay.update(window);
 
-    {
-        let viewport_dims = (
-            (window.inner_size().width as f64 / window.scale_factor()) as u32,
-            (window.inner_size().height as f64 / window.scale_factor()) as u32,
-        );
-        game_state
-            .ui_overlay
-            .queue_message(Message::ViewportDimsChanged(viewport_dims));
-
-        let cursor_pos = winit::dpi::PhysicalPosition::new(
-            game_state.ui_overlay.cursor_position.x / window.inner_size().width as f64,
-            game_state.ui_overlay.cursor_position.y / window.inner_size().height as f64,
-        );
-        game_state
-            .ui_overlay
-            .queue_message(Message::CursorPosChanged(cursor_pos));
-    }
-
     let is_showing_options_menu = game_state.ui_overlay.get_state().is_showing_options_menu;
     let is_showing_cursor_marker = game_state
         .ui_overlay

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -1293,16 +1293,6 @@ pub fn process_window_input(
                 }
             }
         }
-        WindowEvent::Moved(_) => {
-            game_state
-                .ui_overlay
-                .queue_message(Message::MonitorRefreshRateChanged(
-                    window
-                        .current_monitor()
-                        .and_then(|window| window.refresh_rate_millihertz())
-                        .map(|millihertz| millihertz as f32 / 1000.0),
-                ));
-        }
         _ => {}
     };
 
@@ -2089,6 +2079,12 @@ pub fn update_game_state(
             ui_state.debug_settings.culling_frustum_lock_mode,
         );
     }
+
+    game_state
+        .ui_overlay
+        .queue_message(Message::MonitorRefreshRateChanged(
+            engine_state.framerate_limiter.monitor_refresh_rate_hertz(),
+        ));
 
     game_state.ui_overlay.update(window);
 

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -67,7 +67,7 @@ pub const INITIAL_NEAR_PLANE_DISTANCE: f32 = 0.001;
 pub const INITIAL_FAR_PLANE_DISTANCE: f32 = 100000.0;
 pub const INITIAL_FOV_X: f32 = 103.0 * std::f32::consts::PI / 180.0;
 pub const INITIAL_ENABLE_DEPTH_PREPASS: bool = false;
-pub const INITIAL_ENABLE_SHADOWS: bool = true;
+pub const INITIAL_ENABLE_SHADOWS: bool = false;
 pub const INITIAL_RENDER_SCALE: f32 = 1.0;
 pub const INITIAL_TONE_MAPPING_EXPOSURE: f32 = 1.0;
 pub const INITIAL_SHADOW_SMALL_OBJECT_CULLING_SIZE_PIXELS: f32 = 16.0;
@@ -296,6 +296,8 @@ pub async fn init_game_state(
 
         renderer_data_guard.shadow_settings.enable_shadows = INITIAL_ENABLE_SHADOWS;
     }
+
+    // dbg!(&surface_data.surface_config);
 
     let unscaled_framebuffer_size = winit::dpi::PhysicalSize::new(
         surface_data.surface_config.width,

--- a/example_game/src/game.rs
+++ b/example_game/src/game.rs
@@ -67,7 +67,7 @@ pub const INITIAL_NEAR_PLANE_DISTANCE: f32 = 0.001;
 pub const INITIAL_FAR_PLANE_DISTANCE: f32 = 100000.0;
 pub const INITIAL_FOV_X: f32 = 103.0 * std::f32::consts::PI / 180.0;
 pub const INITIAL_ENABLE_DEPTH_PREPASS: bool = false;
-pub const INITIAL_ENABLE_SHADOWS: bool = false;
+pub const INITIAL_ENABLE_SHADOWS: bool = true;
 pub const INITIAL_RENDER_SCALE: f32 = 1.0;
 pub const INITIAL_TONE_MAPPING_EXPOSURE: f32 = 1.0;
 pub const INITIAL_SHADOW_SMALL_OBJECT_CULLING_SIZE_PIXELS: f32 = 16.0;
@@ -297,12 +297,11 @@ pub async fn init_game_state(
         renderer_data_guard.shadow_settings.enable_shadows = INITIAL_ENABLE_SHADOWS;
     }
 
-    // dbg!(&surface_data.surface_config);
-
     let unscaled_framebuffer_size = winit::dpi::PhysicalSize::new(
         surface_data.surface_config.width,
         surface_data.surface_config.height,
     );
+    // TODO: change render scale change to be its own function
     // must call this after changing the render scale
     renderer.resize_surface(surface_data, unscaled_framebuffer_size);
 
@@ -1379,6 +1378,7 @@ pub fn increment_render_scale(
         surface_data.surface_config.width,
         surface_data.surface_config.height,
     );
+    // TODO: change render scale change to be its own function
     // must call this after changing the render scale
     renderer.resize_surface(surface_data, unscaled_framebuffer_size);
     ui_overlay.resize(unscaled_framebuffer_size, window.scale_factor());
@@ -2108,7 +2108,14 @@ pub fn update_game_state(
             1.0 - ui_state.post_effect_settings.skybox_weight,
             ui_state.post_effect_settings.skybox_weight,
         ]);
-        renderer.set_vsync(ui_state.general_settings.enable_vsync, surface_data);
+        renderer.set_present_mode(
+            surface_data,
+            if ui_state.general_settings.enable_vsync {
+                wgpu::PresentMode::AutoVsync
+            } else {
+                wgpu::PresentMode::AutoNoVsync
+            },
+        );
 
         drop(renderer_data_guard);
 

--- a/example_game/src/main.rs
+++ b/example_game/src/main.rs
@@ -8,7 +8,7 @@ mod ui_overlay;
 
 use std::sync::Arc;
 
-use crate::game::handle_window_resize;
+use crate::game::handle_surface_resize;
 use crate::game::init_game_state;
 use crate::game::process_device_input;
 use crate::game::process_window_input;
@@ -116,7 +116,7 @@ async fn start() {
             update_game_state,
             process_window_input,
             process_device_input,
-            handle_window_resize,
+            handle_surface_resize,
             application_start_time,
         );
 

--- a/example_game/src/ui_overlay.rs
+++ b/example_game/src/ui_overlay.rs
@@ -35,6 +35,7 @@ use ikari::renderer::MIN_SHADOW_MAP_BIAS;
 use ikari::time::Instant;
 use ikari::time_tracker::FrameDurations;
 use ikari::time_tracker::FrameInstants;
+use ikari::ui::UiProgramEvents;
 use plotters::prelude::*;
 use plotters_iced::{Chart, ChartWidget, DrawingBackend};
 
@@ -738,6 +739,32 @@ impl<Message> canvas::Program<Message, iced::Theme, iced::Renderer> for UiOverla
         });
 
         vec![clock]
+    }
+}
+
+impl UiProgramEvents for UiOverlay {
+    fn handle_window_event(
+        &self,
+        window: &winit::window::Window,
+        event: &winit::event::WindowEvent,
+    ) -> Vec<Self::Message> {
+        match event {
+            winit::event::WindowEvent::CursorMoved { position, .. } => {
+                vec![Message::CursorPosChanged(
+                    winit::dpi::PhysicalPosition::new(
+                        position.x / window.inner_size().width as f64,
+                        position.y / window.inner_size().height as f64,
+                    ),
+                )]
+            }
+            winit::event::WindowEvent::Resized(size) => {
+                vec![Message::ViewportDimsChanged((
+                    (size.width as f64 / window.scale_factor()) as u32,
+                    (size.height as f64 / window.scale_factor()) as u32,
+                ))]
+            }
+            _ => vec![],
+        }
     }
 }
 

--- a/example_game/src/ui_overlay.rs
+++ b/example_game/src/ui_overlay.rs
@@ -406,7 +406,7 @@ impl modal::StyleSheet for ModalStyle {
 struct FpsChart {
     recent_frame_times: Vec<(Instant, FrameDurations, Option<Duration>)>,
     avg_total_frame_time_millis: Option<f64>,
-    avg_sleep_time_ms: Option<f64>,
+    avg_sleep_and_inputs_time_ms: Option<f64>,
     avg_get_surface_time_ms: Option<f64>,
     avg_update_time_ms: Option<f64>,
     avg_render_time_ms: Option<f64>,
@@ -591,8 +591,10 @@ impl FpsChart {
 
         self.avg_total_frame_time_millis =
             compute_new_avg_frametime(self.avg_total_frame_time_millis, Some(new_durations.total));
-        self.avg_sleep_time_ms =
-            compute_new_avg_frametime(self.avg_sleep_time_ms, new_durations.sleep);
+        self.avg_sleep_and_inputs_time_ms = compute_new_avg_frametime(
+            self.avg_sleep_and_inputs_time_ms,
+            new_durations.sleep_and_inputs,
+        );
         self.avg_get_surface_time_ms =
             compute_new_avg_frametime(self.avg_get_surface_time_ms, new_durations.get_surface);
         self.avg_update_time_ms =
@@ -998,8 +1000,8 @@ impl runtime::Program for UiOverlay {
             }
 
             if self.general_settings.framerate_limit_type != FramerateLimitType::None {
-                if let Some(millis) = self.fps_chart.avg_sleep_time_ms {
-                    let text = text(&format!("Sleep: {:.2}ms", millis));
+                if let Some(millis) = self.fps_chart.avg_sleep_and_inputs_time_ms {
+                    let text = text(&format!("Sleep and inputs: {:.2}ms", millis));
                     rows.push(text.into());
                 }
 

--- a/example_game/src/ui_overlay.rs
+++ b/example_game/src/ui_overlay.rs
@@ -32,6 +32,7 @@ use ikari::renderer::BloomType;
 use ikari::renderer::CullingFrustumLockMode;
 use ikari::renderer::CullingStats;
 use ikari::renderer::MIN_SHADOW_MAP_BIAS;
+use ikari::texture::apply_render_scale;
 use ikari::time::Instant;
 use ikari::time_tracker::FrameDurations;
 use ikari::time_tracker::FrameInstants;
@@ -1277,15 +1278,11 @@ impl runtime::Program for UiOverlay {
                         );
                     }
 
-                    // TODO: expose this as a function in texture.rs
-                    let apply_render_scale =
-                        |dim| ((dim as f32 * render_scale.sqrt()).round() as u32).max(1);
-
                     options = options.push(
                         text(format!(
                             "Render scale ({render_scale:.1}, {}x{})",
-                            apply_render_scale(self.viewport_dims.0),
-                            apply_render_scale(self.viewport_dims.1)
+                            apply_render_scale(self.viewport_dims.0, render_scale),
+                            apply_render_scale(self.viewport_dims.1, render_scale)
                         ))
                         .size(small_text_size),
                     );

--- a/example_game/src/ui_overlay.rs
+++ b/example_game/src/ui_overlay.rs
@@ -110,6 +110,7 @@ pub enum Message {
     FrameCompleted(FrameStats),
     CameraPoseChanged((Vec3, ControlledViewDirection)),
     AudioSoundStatsChanged((GameFilePath, AudioSoundStats)),
+    #[allow(dead_code)]
     VsyncChanged(bool),
     FramerateLimitTypeChanged(FramerateLimitType),
     CustomFramerateLimitChanged(f32),

--- a/example_game/src/ui_overlay.rs
+++ b/example_game/src/ui_overlay.rs
@@ -661,7 +661,6 @@ impl UiOverlay {
         Self {
             clock: Default::default(),
             viewport_dims: (window.inner_size().width, window.inner_size().height),
-            // monitor_refresh_rate: None,
             monitor_refresh_rate: window
                 .current_monitor()
                 .and_then(|monitor| monitor.refresh_rate_millihertz())

--- a/example_game/src/ui_overlay.rs
+++ b/example_game/src/ui_overlay.rs
@@ -957,13 +957,13 @@ impl runtime::Program for UiOverlay {
                 rows.push(text.into());
             }
 
-            // if let Some(millis) = self.fps_chart.avg_get_surface_time_ms {
-            //     let mut text = text(&format!("Get surface: {:.2}ms", millis));
-            //     if is_showing_fps_chart {
-            //         text = text.style(get_chart_line_color(2))
-            //     }
-            //     rows.push(text.into());
-            // }
+            if let Some(millis) = self.fps_chart.avg_get_surface_time_ms {
+                let mut text = text(&format!("Get surface: {:.2}ms", millis));
+                if is_showing_fps_chart {
+                    text = text.style(get_chart_line_color(2))
+                }
+                rows.push(text.into());
+            }
 
             if let Some(millis) = self.fps_chart.avg_update_time_ms {
                 let mut text = text(&format!("Update: {:.2}ms", millis));

--- a/ikari/src/engine_state.rs
+++ b/ikari/src/engine_state.rs
@@ -1,6 +1,7 @@
 use crate::{
     asset_loader::{AssetBinder, AssetLoader},
     audio::{AudioManager, AudioStreams},
+    framerate_limiter::FrameRateLimiter,
     mutex::Mutex,
     physics::PhysicsState,
     scene::Scene,
@@ -12,7 +13,8 @@ use std::sync::Arc;
 
 pub struct EngineState {
     pub scene: Scene,
-    pub(crate) time_tracker: TimeTracker,
+    pub time_tracker: TimeTracker,
+    pub framerate_limiter: FrameRateLimiter,
     pub physics_state: PhysicsState,
     pub audio_streams: AudioStreams,
     pub audio_manager: Arc<Mutex<AudioManager>>,
@@ -32,13 +34,10 @@ impl EngineState {
             audio_streams,
             audio_manager,
             time_tracker: Default::default(),
+            framerate_limiter: Default::default(),
             physics_state: PhysicsState::new(),
             asset_loader,
             asset_binder,
         })
-    }
-
-    pub fn time(&self) -> TimeTracker {
-        self.time_tracker
     }
 }

--- a/ikari/src/engine_state.rs
+++ b/ikari/src/engine_state.rs
@@ -1,7 +1,7 @@
 use crate::{
     asset_loader::{AssetBinder, AssetLoader},
     audio::{AudioManager, AudioStreams},
-    framerate_limiter::FrameRateLimiter,
+    framerate_limiter::FramerateLimiter,
     mutex::Mutex,
     physics::PhysicsState,
     scene::Scene,
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub struct EngineState {
     pub scene: Scene,
     pub time_tracker: TimeTracker,
-    pub framerate_limiter: FrameRateLimiter,
+    pub framerate_limiter: FramerateLimiter,
     pub physics_state: PhysicsState,
     pub audio_streams: AudioStreams,
     pub audio_manager: Arc<Mutex<AudioManager>>,

--- a/ikari/src/framerate_limiter.rs
+++ b/ikari/src/framerate_limiter.rs
@@ -1,0 +1,134 @@
+use crate::time_tracker::TimeTracker;
+
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub enum FramerateLimit {
+    #[default]
+    None,
+    Monitor,
+    Custom(f32),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FramerateLimitType {
+    None,
+    Monitor,
+    Custom,
+}
+
+impl FramerateLimitType {
+    pub const ALL: [FramerateLimitType; 3] = [
+        FramerateLimitType::None,
+        FramerateLimitType::Monitor,
+        FramerateLimitType::Custom,
+    ];
+}
+
+impl std::fmt::Display for FramerateLimitType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                FramerateLimitType::None => "None",
+                FramerateLimitType::Monitor => "Monitor",
+                FramerateLimitType::Custom => "Custom",
+            }
+        )
+    }
+}
+
+impl From<FramerateLimit> for FramerateLimitType {
+    fn from(value: FramerateLimit) -> Self {
+        match value {
+            FramerateLimit::None => FramerateLimitType::None,
+            FramerateLimit::Monitor => FramerateLimitType::Monitor,
+            FramerateLimit::Custom(_) => FramerateLimitType::Custom,
+        }
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct FrameRateLimiter {
+    limit: FramerateLimit,
+    current_sleep_start: Option<crate::time::Instant>,
+    monitor_refresh_rate: Option<f32>,
+}
+
+impl FrameRateLimiter {
+    pub fn framerate_limit(&self) -> FramerateLimit {
+        self.limit
+    }
+
+    pub fn set_framerate_limit(&mut self, limit: FramerateLimit) {
+        self.limit = limit;
+    }
+
+    pub(crate) fn set_monitor_refresh_rate(&mut self, monitor_refresh_rate: Option<f32>) {
+        self.monitor_refresh_rate = monitor_refresh_rate;
+    }
+
+    /// starts and ends the sleep timer.
+    /// call get_remaining_sleep_time immediately after this to know if we need should sleep
+    pub(crate) fn update(&mut self, time_tracker: &TimeTracker) {
+        let Some(sleep_period_secs) = self.get_sleep_period_secs(time_tracker) else {
+            self.current_sleep_start = None;
+            return;
+        };
+
+        let current_sleep_start = self
+            .current_sleep_start
+            .get_or_insert_with(|| crate::time::Instant::now());
+        let remaining_sleep_time =
+            (sleep_period_secs - current_sleep_start.elapsed().as_secs_f64()).max(0.0);
+
+        if remaining_sleep_time <= 0.0 {
+            self.current_sleep_start = None;
+        }
+    }
+
+    /// duration will never be 0
+    pub(crate) fn get_remaining_sleep_time(
+        &self,
+        time_tracker: &TimeTracker,
+    ) -> Option<crate::time::Duration> {
+        let Some(sleep_period_secs) = self.get_sleep_period_secs(time_tracker) else {
+            return None;
+        };
+
+        let Some(current_sleep_start) = self.current_sleep_start else {
+            return None;
+        };
+
+        let remaining_sleep_time =
+            (sleep_period_secs - current_sleep_start.elapsed().as_secs_f64()).max(0.0);
+
+        if remaining_sleep_time <= 0.0 {
+            return None;
+        }
+
+        Some(crate::time::Duration::from_secs_f64(remaining_sleep_time))
+    }
+
+    /// returns None if sleeping is disabled
+    pub fn get_sleep_period_secs(&self, time_tracker: &TimeTracker) -> Option<f64> {
+        let Some(last_frame_busy_time_secs) = time_tracker.last_frame_busy_time_secs() else {
+            return None;
+        };
+
+        let Some(limit_hz) = (match self.limit {
+            FramerateLimit::None => None,
+            FramerateLimit::Monitor => self.monitor_refresh_rate,
+            FramerateLimit::Custom(custom_limit) => Some(custom_limit),
+        }) else {
+            return None;
+        };
+
+        let limit_period_secs = 1.0 / limit_hz as f64;
+        let sleep_period = (limit_period_secs - last_frame_busy_time_secs).max(0.0) * 1.01;
+        if sleep_period > 0.0 {
+            Some(sleep_period)
+        } else {
+            None
+        }
+    }
+}

--- a/ikari/src/framerate_limiter.rs
+++ b/ikari/src/framerate_limiter.rs
@@ -92,22 +92,16 @@ impl FrameRateLimiter {
             return false;
         }
 
-        match self.current_sleep_start {
-            None => {
-                self.current_sleep_start = Some(crate::time::Instant::now());
-                true
-            }
-            Some(current_sleep_start) => {
-                let remaining_sleep_time =
-                    sleep_period_secs - current_sleep_start.elapsed().as_secs_f64();
+        let current_sleep_start = *self
+            .current_sleep_start
+            .get_or_insert_with(|| crate::time::Instant::now());
+        let remaining_sleep_time = sleep_period_secs - current_sleep_start.elapsed().as_secs_f64();
 
-                if remaining_sleep_time > 0.0 {
-                    true
-                } else {
-                    self.current_sleep_start = None;
-                    false
-                }
-            }
+        if remaining_sleep_time > 0.0 {
+            true
+        } else {
+            self.current_sleep_start = None;
+            false
         }
     }
 }

--- a/ikari/src/framerate_limiter.rs
+++ b/ikari/src/framerate_limiter.rs
@@ -48,13 +48,13 @@ impl From<FramerateLimit> for FramerateLimitType {
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
-pub struct FrameRateLimiter {
+pub struct FramerateLimiter {
     limit: FramerateLimit,
     current_sleep_start: Option<crate::time::Instant>,
     monitor_refresh_rate_hertz: Option<f32>,
 }
 
-impl FrameRateLimiter {
+impl FramerateLimiter {
     pub fn framerate_limit(&self) -> FramerateLimit {
         self.limit
     }
@@ -73,6 +73,10 @@ impl FrameRateLimiter {
 
     /// updates the internal state of the limiter and returns true if we're sleeping
     pub(crate) fn update(&mut self, time_tracker: &TimeTracker) -> bool {
+        if !Self::is_supported() {
+            return false;
+        }
+
         let Some(last_frame_busy_time_secs) = time_tracker.last_frame_busy_time_secs() else {
             return false;
         };
@@ -103,6 +107,18 @@ impl FrameRateLimiter {
         } else {
             self.current_sleep_start = None;
             false
+        }
+    }
+
+    pub fn is_supported() -> bool {
+        #[cfg(target_arch = "wasm32")]
+        {
+            return false;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            return true;
         }
     }
 }

--- a/ikari/src/framerate_limiter.rs
+++ b/ikari/src/framerate_limiter.rs
@@ -95,6 +95,7 @@ impl FrameRateLimiter {
         let current_sleep_start = *self
             .current_sleep_start
             .get_or_insert_with(|| crate::time::Instant::now());
+
         let remaining_sleep_time = sleep_period_secs - current_sleep_start.elapsed().as_secs_f64();
 
         if remaining_sleep_time > 0.0 {

--- a/ikari/src/framerate_limiter.rs
+++ b/ikari/src/framerate_limiter.rs
@@ -98,7 +98,7 @@ impl FramerateLimiter {
 
         let current_sleep_start = *self
             .current_sleep_start
-            .get_or_insert_with(|| crate::time::Instant::now());
+            .get_or_insert_with(crate::time::Instant::now);
 
         let remaining_sleep_time = sleep_period_secs - current_sleep_start.elapsed().as_secs_f64();
 
@@ -113,12 +113,12 @@ impl FramerateLimiter {
     pub fn is_supported() -> bool {
         #[cfg(target_arch = "wasm32")]
         {
-            return false;
+            false
         }
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            return true;
+            true
         }
     }
 }

--- a/ikari/src/framerate_limiter.rs
+++ b/ikari/src/framerate_limiter.rs
@@ -51,7 +51,7 @@ impl From<FramerateLimit> for FramerateLimitType {
 pub struct FrameRateLimiter {
     limit: FramerateLimit,
     current_sleep_start: Option<crate::time::Instant>,
-    monitor_refresh_rate: Option<f32>,
+    monitor_refresh_rate_hertz: Option<f32>,
 }
 
 impl FrameRateLimiter {
@@ -63,8 +63,12 @@ impl FrameRateLimiter {
         self.limit = limit;
     }
 
-    pub(crate) fn set_monitor_refresh_rate(&mut self, monitor_refresh_rate: Option<f32>) {
-        self.monitor_refresh_rate = monitor_refresh_rate;
+    pub fn monitor_refresh_rate_hertz(&self) -> Option<f32> {
+        self.monitor_refresh_rate_hertz
+    }
+
+    pub(crate) fn set_monitor_refresh_rate(&mut self, monitor_refresh_rate_hertz: Option<f32>) {
+        self.monitor_refresh_rate_hertz = monitor_refresh_rate_hertz;
     }
 
     /// updates the internal state of the limiter and returns true if we're sleeping
@@ -75,7 +79,7 @@ impl FrameRateLimiter {
 
         let Some(limit_hz) = (match self.limit {
             FramerateLimit::None => None,
-            FramerateLimit::Monitor => self.monitor_refresh_rate,
+            FramerateLimit::Monitor => self.monitor_refresh_rate_hertz,
             FramerateLimit::Custom(custom_limit) => Some(custom_limit),
         }) else {
             return false;

--- a/ikari/src/gameloop.rs
+++ b/ikari/src/gameloop.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::engine_state::EngineState;
 use crate::renderer::{Renderer, SurfaceData};
 use crate::time::Instant;
-use crate::ui::IkariUiContainer;
+use crate::ui::{IkariUiContainer, UiProgramEvents};
 use crate::web_canvas_manager::WebCanvasManager;
 
 use winit::event_loop::EventLoopWindowTarget;
@@ -15,7 +15,7 @@ use winit::{
 
 pub trait GameState<UiOverlay>
 where
-    UiOverlay: iced_winit::runtime::Program<Renderer = iced::Renderer> + 'static,
+    UiOverlay: iced_winit::runtime::Program<Renderer = iced::Renderer> + UiProgramEvents + 'static,
 {
     fn get_ui_container(&mut self) -> &mut IkariUiContainer<UiOverlay>;
 }
@@ -55,7 +55,7 @@ pub fn run<
     OnDeviceEventFunction: FnMut(GameContext<GameStateType>, &winit::event::DeviceEvent) + 'static,
     OnWindowResizeFunction:
         FnMut(GameContext<GameStateType>, winit::dpi::PhysicalSize<u32>) + 'static,
-    UiOverlay: iced_winit::runtime::Program<Renderer = iced::Renderer> + 'static,
+    UiOverlay: iced_winit::runtime::Program<Renderer = iced::Renderer> + UiProgramEvents + 'static,
     GameStateType: GameState<UiOverlay> + 'static,
 {
     let mut logged_start_time = false;

--- a/ikari/src/gameloop.rs
+++ b/ikari/src/gameloop.rs
@@ -213,6 +213,7 @@ pub fn run<
                         Some(surface_data.surface.get_current_texture());
                 }
 
+                // TODO: this is not correct on wasm
                 engine_state.time_tracker.on_get_surface_completed();
 
                 // start the frame right away so that input processing gets tracked by the time tracker

--- a/ikari/src/gameloop.rs
+++ b/ikari/src/gameloop.rs
@@ -82,7 +82,7 @@ pub fn run<
                 // TODO: the real 'frame start' time should come immediately after get_current_texture call, because this ends right
                 //       after the vblank under vsync. on_frame_started and profiling::finish_frame! should be moved around accordingly.
                 if sleep_start.is_none() {
-                    dbg!("on frame start");
+                    // dbg!("on frame start");
                     engine_state.time_tracker.on_frame_started();
 
                     if !logged_start_time && engine_state.time_tracker.last_frame_times().is_some()
@@ -106,7 +106,8 @@ pub fn run<
                         let refresh_rate_period_secs = 1000.0 / monitor_refresh_rate as f64;
                         let sleep_time =
                             (refresh_rate_period_secs - last_frame_busy_time_secs).max(0.0) * 1.01;
-                        let sleep_time = 0.0;
+                        // let sleep_time = 0.016;
+                        // let sleep_time = 0.0;
                         // dbg!(
                         //     refresh_rate_period_secs * 1000.0,
                         //     last_frame_busy_time_secs * 1000.0,

--- a/ikari/src/gameloop.rs
+++ b/ikari/src/gameloop.rs
@@ -69,31 +69,14 @@ where
             .map(|millihertz| millihertz as f32 / 1000.0),
     );
 
-    // let mut latest_surface_texture_result = None;
-
     let mut pending_resize_event: Option<winit::dpi::PhysicalSize<u32>> = None;
 
     engine_state.time_tracker.on_frame_started();
 
     let mut force_reconfigure_surface = false;
 
-    // web_canvas_manager.on_update(window.inner_size());
-
     let handler = move |event: Event<()>, elwt: &EventLoopWindowTarget<()>| {
-        #[cfg(target_arch = "wasm32")]
-        {
-            let new_size = winit::dpi::PhysicalSize::new(
-                (web_canvas_manager.canvas_container.offset_width() as f64
-                    * web_canvas_manager.window.scale_factor()) as u32,
-                (web_canvas_manager.canvas_container.offset_height() as f64
-                    * web_canvas_manager.window.scale_factor()) as u32,
-            );
-            // log::info!("1 {:?}, {:?}", new_size, window.scale_factor());
-            if web_canvas_manager.window.inner_size() != new_size {
-                renderer.resize_surface(&surface_data, new_size);
-                // let _resized_immediately = self.window.request_inner_size(new_size);
-            }
-        }
+        web_canvas_manager.on_update(&event);
 
         match event {
             Event::WindowEvent {
@@ -138,7 +121,6 @@ where
 
                 let surface_texture_result = surface_data.surface.get_current_texture();
 
-                // TODO: this is not correct on wasm
                 engine_state.time_tracker.on_get_surface_completed();
 
                 if let Some(new_size) = pending_resize_event.take() {
@@ -153,12 +135,6 @@ where
                         },
                         new_size,
                     );
-
-                    #[cfg(target_arch = "wasm32")]
-                    {
-                        let _resized_immediately =
-                            web_canvas_manager.window.request_inner_size(new_size);
-                    }
                 }
 
                 force_reconfigure_surface = false;
@@ -225,7 +201,6 @@ where
             } if window_id == window.id() => {
                 match &event {
                     WindowEvent::Resized(size) => {
-                        // log::info!("{:?}, {:?}", size, window.scale_factor());
                         renderer.resize_surface(&surface_data, *size);
                     }
                     WindowEvent::ScaleFactorChanged { .. } => {

--- a/ikari/src/gameloop.rs
+++ b/ikari/src/gameloop.rs
@@ -83,6 +83,9 @@ where
                 event: WindowEvent::RedrawRequested,
                 ..
             } => {
+                // TODO: instead of spinning, do a real sleep (spin-sleep crate) and when it's finally done,
+                // call request redraw and return once to allow inputs to be processed once quickly before we
+                // start rendering. Would that even work?
                 let sleeping = engine_state
                     .framerate_limiter
                     .update(&engine_state.time_tracker);
@@ -140,7 +143,6 @@ where
                 force_reconfigure_surface = false;
                 match surface_texture_result {
                     Ok(surface_texture) => {
-                        // log::info!("{:?}", &surface_texture);
                         if let Err(err) = renderer.render(
                             &mut engine_state,
                             &surface_data,

--- a/ikari/src/gameloop.rs
+++ b/ikari/src/gameloop.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::engine_state::EngineState;
-// use crate::framerate_limiter::FrameRateLimiterState;
 use crate::renderer::{Renderer, SurfaceData};
 use crate::time::Instant;
 use crate::ui::IkariUiContainer;
@@ -144,7 +143,7 @@ pub fn run<
                     Err(err) => match err {
                         // Reconfigure the surface if lost
                         wgpu::SurfaceError::Lost => {
-                            renderer.resize_surface(&mut surface_data, window.inner_size());
+                            renderer.resize_surface(&surface_data, window.inner_size());
                         }
                         wgpu::SurfaceError::OutOfMemory => {
                             elwt.exit();
@@ -200,13 +199,13 @@ pub fn run<
                 match &event {
                     WindowEvent::Resized(size) => {
                         if size.width > 0 && size.height > 0 {
-                            renderer.resize_surface(&mut surface_data, *size);
+                            renderer.resize_surface(&surface_data, *size);
                         }
                     }
                     WindowEvent::ScaleFactorChanged { .. } => {
                         let size = window.inner_size();
                         if size.width > 0 && size.height > 0 {
-                            renderer.resize_surface(&mut surface_data, size);
+                            renderer.resize_surface(&surface_data, size);
                         }
                     }
                     WindowEvent::CloseRequested => {

--- a/ikari/src/lib.rs
+++ b/ikari/src/lib.rs
@@ -11,6 +11,7 @@ pub mod camera;
 pub mod collisions;
 pub mod engine_state;
 pub mod file_manager;
+pub mod framerate_limiter;
 pub mod gameloop;
 pub mod gltf_loader;
 pub mod math;

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -19,7 +19,7 @@ use crate::skinning::{get_all_bone_data, AllBoneTransforms};
 use crate::texture::Texture;
 use crate::time::Duration;
 use crate::transform::{look_in_dir, Transform, TransformBuilder};
-use crate::ui::IkariUiContainer;
+use crate::ui::{IkariUiContainer, UiProgramEvents};
 use crate::wasm_not_sync::WasmNotArc;
 
 use std::collections::{hash_map::Entry, HashMap};
@@ -4096,7 +4096,8 @@ impl Renderer {
         ui_overlay: &mut IkariUiContainer<UiOverlay>,
     ) -> anyhow::Result<()>
     where
-        UiOverlay: iced_winit::runtime::Program<Renderer = iced::Renderer> + 'static,
+        UiOverlay:
+            iced_winit::runtime::Program<Renderer = iced::Renderer> + UiProgramEvents + 'static,
     {
         if surface_data.surface_config.width == 0 || surface_data.surface_config.height == 0 {
             return Ok(());
@@ -5202,7 +5203,8 @@ impl Renderer {
         ui_overlay: &mut IkariUiContainer<UiOverlay>,
     ) -> anyhow::Result<()>
     where
-        UiOverlay: iced_winit::runtime::Program<Renderer = iced::Renderer> + 'static,
+        UiOverlay:
+            iced_winit::runtime::Program<Renderer = iced::Renderer> + UiProgramEvents + 'static,
     {
         let mut data_guard = self.data.lock();
         let data: &mut RendererData = &mut data_guard;

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -4707,11 +4707,11 @@ impl Renderer {
             .drain()
             .collect();
 
-        // if PRESORT_INSTANCES_BY_MESH_MATERIAL {
-        //     pbr_mesh_instances.sort_by_key(|((mesh_index, material_index), _)| {
-        //         ((*mesh_index as u128) << 64) + *material_index as u128
-        //     });
-        // }
+        if PRESORT_INSTANCES_BY_MESH_MATERIAL {
+            pbr_mesh_instances.sort_by_key(|((mesh_index, material_index), _)| {
+                ((*mesh_index as u128) << 64) + *material_index as u128
+            });
+        }
 
         pbr_mesh_instances.sort_by(
             |(_, (_, _, dist_sq_from_player_a)), (_, (_, _, dist_sq_from_player_b))| {

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -627,7 +627,7 @@ impl BaseRenderer {
         surface_config.usage = wgpu::TextureUsages::RENDER_ATTACHMENT;
         // surface_config.format = wgpu::TextureFormat::Bgra8UnormSrgb;
         surface_config.alpha_mode = wgpu::CompositeAlphaMode::Auto;
-        surface_config.present_mode = wgpu::PresentMode::Mailbox;
+        surface_config.present_mode = wgpu::PresentMode::Fifo;
         surface_config.view_formats = vec![surface_config.format.add_srgb_suffix()];
         surface_config.desired_maximum_frame_latency = 1;
         surface.configure(&base.device, &surface_config);
@@ -3377,7 +3377,7 @@ impl Renderer {
 
     pub fn set_vsync(&self, vsync: bool, surface_data: &mut SurfaceData) {
         let new_present_mode = if vsync {
-            wgpu::PresentMode::Mailbox
+            wgpu::PresentMode::Fifo
         } else {
             wgpu::PresentMode::AutoNoVsync
         };

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -630,7 +630,7 @@ impl BaseRenderer {
         surface_config.present_mode = wgpu::PresentMode::AutoVsync;
         surface_config.view_formats = vec![surface_config.format.add_srgb_suffix()];
         // this caused problems on Windows on dx12 and vulkan..
-        surface_config.desired_maximum_frame_latency = 1;
+        // surface_config.desired_maximum_frame_latency = 1;
         surface.configure(&base.device, &surface_config);
 
         let capabilities = surface.get_capabilities(&base.adapter);
@@ -4116,12 +4116,7 @@ impl Renderer {
         }
 
         self.update_internal(engine_state, &surface_data.surface_config);
-        self.render_internal(
-            engine_state,
-            surface_texture,
-            // surface_data.surface.get_current_texture()?,
-            ui_overlay,
-        )
+        self.render_internal(engine_state, surface_texture, ui_overlay)
     }
 
     fn get_node_cam_intersection_result(

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -3403,7 +3403,11 @@ impl Renderer {
         new_pending_surface_config.height = new_unscaled_framebuffer_size.height;
     }
 
-    pub fn reconfigure_surface_if_needed(&self, surface_data: &mut SurfaceData) -> bool {
+    pub fn reconfigure_surface_if_needed(
+        &self,
+        surface_data: &mut SurfaceData,
+        force_reconfigure: bool,
+    ) -> bool {
         let mut private_data_guard = self.private_data.lock();
 
         let data_guard = self.data.lock();
@@ -3419,11 +3423,18 @@ impl Renderer {
             surface_data.surface_config.height,
         ) != (new_surface_config.width, new_surface_config.height);
 
+        if surface_resized {
+            log::debug!(
+                "Resizing surface to {:?}",
+                (new_surface_config.width, new_surface_config.height)
+            );
+        }
+
         let new_render_scale = data_guard.general_settings.render_scale;
         let current_render_scale = private_data_guard.current_render_scale;
         let render_scale_changed = current_render_scale != new_render_scale;
 
-        if !surface_config_changed && !render_scale_changed {
+        if !surface_config_changed && !render_scale_changed && !force_reconfigure {
             return false;
         }
 

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -992,17 +992,9 @@ impl std::fmt::Display for BloomType {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum FramerateLimit {
-    None,
-    Monitor,
-    Custom(f32),
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct GeneralSettings {
     pub render_scale: f32,
     pub enable_depth_prepass: bool,
-    pub framerate_limit: FramerateLimit,
 }
 
 impl Default for GeneralSettings {
@@ -1010,7 +1002,6 @@ impl Default for GeneralSettings {
         Self {
             render_scale: 1.0,
             enable_depth_prepass: false,
-            framerate_limit: FramerateLimit::Custom(29.5),
         }
     }
 }

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -3723,7 +3723,7 @@ impl Renderer {
             })
             .collect::<Vec<_>>();
 
-        return surface_resized;
+        surface_resized
     }
 
     #[profiling::function]
@@ -6142,227 +6142,219 @@ impl Renderer {
             ..
         } = data.debug_settings;
 
-        {
-            profiling::scope!("theloop");
+        for node in engine_state.scene.nodes() {
+            let transform = Mat4::from(
+                engine_state
+                    .scene
+                    .get_global_transform_for_node_opt(node.id()),
+            );
+            if let Some(GameNodeVisual {
+                mesh_index,
+                material,
+                wireframe,
+                ..
+            }) = node.visual.clone()
+            {
+                let node_bounding_sphere =
+                    engine_state.scene.get_node_bounding_sphere_opt(node.id());
+                let dist_sq_from_player = node_bounding_sphere
+                    .center
+                    .distance_squared(camera_position)
+                    - node_bounding_sphere.radius;
 
-            for node in engine_state.scene.nodes() {
-                let transform = Mat4::from(
-                    engine_state
-                        .scene
-                        .get_global_transform_for_node_opt(node.id()),
-                );
-                if let Some(GameNodeVisual {
-                    mesh_index,
-                    material,
-                    wireframe,
-                    ..
-                }) = node.visual.clone()
-                {
-                    let node_bounding_sphere =
-                        engine_state.scene.get_node_bounding_sphere_opt(node.id());
-                    let dist_sq_from_player = node_bounding_sphere
-                        .center
-                        .distance_squared(camera_position)
-                        - node_bounding_sphere.radius;
+                match (material, enable_wireframe_mode, wireframe) {
+                    (
+                        Material::Pbr {
+                            binded_material_index,
+                            dynamic_pbr_params,
+                        },
+                        false,
+                        false,
+                    ) => {
+                        stats.total_count += 1;
 
-                    match (material, enable_wireframe_mode, wireframe) {
-                        (
-                            Material::Pbr {
-                                binded_material_index,
-                                dynamic_pbr_params,
-                            },
-                            false,
-                            false,
-                        ) => {
-                            stats.total_count += 1;
+                        Self::get_node_culling_mask(
+                            node,
+                            data,
+                            engine_state,
+                            culling_frustum,
+                            point_lights_frusta,
+                            resolved_directional_light_cascades,
+                            &mut tmp_node_culling_mask,
+                        );
 
-                            Self::get_node_culling_mask(
-                                node,
-                                data,
-                                engine_state,
-                                culling_frustum,
-                                point_lights_frusta,
-                                resolved_directional_light_cascades,
-                                &mut tmp_node_culling_mask,
-                            );
+                        let mut completely_culled = true;
 
-                            let mut completely_culled = true;
-
-                            for element in tmp_node_culling_mask.iter().by_vals() {
-                                if element {
-                                    completely_culled = false;
-                                    break;
-                                }
+                        for element in tmp_node_culling_mask.iter().by_vals() {
+                            if element {
+                                completely_culled = false;
+                                break;
                             }
+                        }
 
-                            if record_culling_stats {
-                                for (camera_index, element) in
-                                    tmp_node_culling_mask.iter().by_vals().enumerate()
-                                {
-                                    if element {
-                                        culled_object_counts_per_camera[camera_index] += 1;
-                                    }
-                                }
-
-                                if completely_culled {
-                                    stats.completely_culled_count += 1;
+                        if record_culling_stats {
+                            for (camera_index, element) in
+                                tmp_node_culling_mask.iter().by_vals().enumerate()
+                            {
+                                if element {
+                                    culled_object_counts_per_camera[camera_index] += 1;
                                 }
                             }
 
                             if completely_culled {
+                                stats.completely_culled_count += 1;
+                            }
+                        }
+
+                        if completely_culled {
+                            continue;
+                        }
+
+                        let gpu_instance = GpuPbrMeshInstance::new(
+                            transform,
+                            dynamic_pbr_params.unwrap_or_else(|| {
+                                data.binded_pbr_materials[binded_material_index].dynamic_pbr_params
+                            }),
+                        );
+
+                        match private_data
+                            .pbr_mesh_index_to_gpu_instances
+                            .entry((mesh_index, binded_material_index))
+                        {
+                            Entry::Occupied(mut entry) => {
+                                entry.get_mut().0.push(gpu_instance);
+                                // combine instance culling masks
+                                *entry.get_mut().1 |= &tmp_node_culling_mask;
+                            }
+                            Entry::Vacant(entry) => {
+                                entry.insert((
+                                    smallvec![gpu_instance],
+                                    tmp_node_culling_mask.clone(),
+                                    dist_sq_from_player,
+                                ));
+                            }
+                        }
+                    }
+                    (material, enable_wireframe_mode, is_node_wireframe) => {
+                        let (color, is_transparent) = match material {
+                            Material::Unlit { color } => ([color.x, color.y, color.z, 1.0], false),
+                            Material::Transparent {
+                                color,
+                                premultiplied_alpha,
+                            } => {
+                                (
+                                    if premultiplied_alpha {
+                                        [color.x, color.y, color.z, color.w]
+                                    } else {
+                                        // transparent pipeline requires alpha to be premultiplied.
+                                        [
+                                            color.w * color.x,
+                                            color.w * color.y,
+                                            color.w * color.z,
+                                            color.w,
+                                        ]
+                                    },
+                                    true,
+                                )
+                            }
+                            Material::Pbr {
+                                binded_material_index,
+                                dynamic_pbr_params,
+                            } => {
+                                // fancy logic for picking what the wireframe lines
+                                // color will be by checking the pbr material
+                                let DynamicPbrParams {
+                                    base_color_factor,
+                                    emissive_factor,
+                                    ..
+                                } = dynamic_pbr_params.unwrap_or_else(|| {
+                                    data.binded_pbr_materials[binded_material_index]
+                                        .dynamic_pbr_params
+                                });
+                                let should_take_color = |as_slice: &[f32]| {
+                                    let is_all_zero = as_slice.iter().all(|&x| x == 0.0);
+                                    let is_all_one = as_slice.iter().all(|&x| x == 1.0);
+                                    !is_all_zero && !is_all_one
+                                };
+                                let base_color_factor_arr: [f32; 4] = base_color_factor.into();
+                                let emissive_factor_arr: [f32; 3] = emissive_factor.into();
+                                (
+                                    if should_take_color(&base_color_factor_arr[0..3]) {
+                                        [
+                                            base_color_factor.x,
+                                            base_color_factor.y,
+                                            base_color_factor.z,
+                                            base_color_factor.w,
+                                        ]
+                                    } else if should_take_color(&emissive_factor_arr) {
+                                        [
+                                            emissive_factor.x,
+                                            emissive_factor.y,
+                                            emissive_factor.z,
+                                            1.0,
+                                        ]
+                                    } else {
+                                        DEFAULT_WIREFRAME_COLOR
+                                    },
+                                    false,
+                                )
+                            }
+                        };
+
+                        if enable_wireframe_mode || is_node_wireframe {
+                            let wireframe_mesh_index = data
+                                .binded_wireframe_meshes
+                                .iter()
+                                .enumerate()
+                                .find(|(_, wireframe_mesh)| {
+                                    wireframe_mesh.source_mesh_index == mesh_index
+                                })
+                                .map(|(index, _)| index);
+
+                            if wireframe_mesh_index.is_none() {
+                                if is_node_wireframe {
+                                    log::error!("Attempted to draw mesh in wireframe mode without binding a corresponding wireframe mesh. Mesh will not be draw. mesh_index={mesh_index:?} node={node:?}");
+                                }
                                 continue;
                             }
 
-                            let gpu_instance = GpuPbrMeshInstance::new(
-                                transform,
-                                dynamic_pbr_params.unwrap_or_else(|| {
-                                    data.binded_pbr_materials[binded_material_index]
-                                        .dynamic_pbr_params
-                                }),
-                            );
+                            let wireframe_mesh_index = wireframe_mesh_index
+                                .expect("Should have checked that it isn't None");
 
-                            match private_data
-                                .pbr_mesh_index_to_gpu_instances
-                                .entry((mesh_index, binded_material_index))
+                            let gpu_instance = GpuWireframeMeshInstance {
+                                color,
+                                model_transform: transform,
+                            };
+                            match wireframe_mesh_index_to_gpu_instances.entry(wireframe_mesh_index)
                             {
                                 Entry::Occupied(mut entry) => {
-                                    entry.get_mut().0.push(gpu_instance);
-                                    // combine instance culling masks
-                                    *entry.get_mut().1 |= &tmp_node_culling_mask;
+                                    entry.get_mut().push(gpu_instance);
                                 }
                                 Entry::Vacant(entry) => {
-                                    entry.insert((
-                                        smallvec![gpu_instance],
-                                        tmp_node_culling_mask.clone(),
-                                        dist_sq_from_player,
-                                    ));
+                                    entry.insert(vec![gpu_instance]);
                                 }
                             }
-                        }
-                        (material, enable_wireframe_mode, is_node_wireframe) => {
-                            let (color, is_transparent) = match material {
-                                Material::Unlit { color } => {
-                                    ([color.x, color.y, color.z, 1.0], false)
-                                }
-                                Material::Transparent {
-                                    color,
-                                    premultiplied_alpha,
-                                } => {
-                                    (
-                                        if premultiplied_alpha {
-                                            [color.x, color.y, color.z, color.w]
-                                        } else {
-                                            // transparent pipeline requires alpha to be premultiplied.
-                                            [
-                                                color.w * color.x,
-                                                color.w * color.y,
-                                                color.w * color.z,
-                                                color.w,
-                                            ]
-                                        },
-                                        true,
-                                    )
-                                }
-                                Material::Pbr {
-                                    binded_material_index,
-                                    dynamic_pbr_params,
-                                } => {
-                                    // fancy logic for picking what the wireframe lines
-                                    // color will be by checking the pbr material
-                                    let DynamicPbrParams {
-                                        base_color_factor,
-                                        emissive_factor,
-                                        ..
-                                    } = dynamic_pbr_params.unwrap_or_else(|| {
-                                        data.binded_pbr_materials[binded_material_index]
-                                            .dynamic_pbr_params
-                                    });
-                                    let should_take_color = |as_slice: &[f32]| {
-                                        let is_all_zero = as_slice.iter().all(|&x| x == 0.0);
-                                        let is_all_one = as_slice.iter().all(|&x| x == 1.0);
-                                        !is_all_zero && !is_all_one
-                                    };
-                                    let base_color_factor_arr: [f32; 4] = base_color_factor.into();
-                                    let emissive_factor_arr: [f32; 3] = emissive_factor.into();
-                                    (
-                                        if should_take_color(&base_color_factor_arr[0..3]) {
-                                            [
-                                                base_color_factor.x,
-                                                base_color_factor.y,
-                                                base_color_factor.z,
-                                                base_color_factor.w,
-                                            ]
-                                        } else if should_take_color(&emissive_factor_arr) {
-                                            [
-                                                emissive_factor.x,
-                                                emissive_factor.y,
-                                                emissive_factor.z,
-                                                1.0,
-                                            ]
-                                        } else {
-                                            DEFAULT_WIREFRAME_COLOR
-                                        },
-                                        false,
-                                    )
-                                }
+                        } else if is_transparent {
+                            let gpu_instance = GpuTransparentMeshInstance {
+                                color,
+                                model_transform: transform,
                             };
-
-                            if enable_wireframe_mode || is_node_wireframe {
-                                let wireframe_mesh_index = data
-                                    .binded_wireframe_meshes
-                                    .iter()
-                                    .enumerate()
-                                    .find(|(_, wireframe_mesh)| {
-                                        wireframe_mesh.source_mesh_index == mesh_index
-                                    })
-                                    .map(|(index, _)| index);
-
-                                if wireframe_mesh_index.is_none() {
-                                    if is_node_wireframe {
-                                        log::error!("Attempted to draw mesh in wireframe mode without binding a corresponding wireframe mesh. Mesh will not be draw. mesh_index={mesh_index:?} node={node:?}");
-                                    }
-                                    continue;
+                            transparent_meshes.push((
+                                mesh_index,
+                                gpu_instance,
+                                dist_sq_from_player,
+                            ));
+                        } else {
+                            let gpu_instance = GpuUnlitMeshInstance {
+                                color,
+                                model_transform: transform,
+                            };
+                            match unlit_mesh_index_to_gpu_instances.entry(mesh_index) {
+                                Entry::Occupied(mut entry) => {
+                                    entry.get_mut().push(gpu_instance);
                                 }
-
-                                let wireframe_mesh_index = wireframe_mesh_index
-                                    .expect("Should have checked that it isn't None");
-
-                                let gpu_instance = GpuWireframeMeshInstance {
-                                    color,
-                                    model_transform: transform,
-                                };
-                                match wireframe_mesh_index_to_gpu_instances
-                                    .entry(wireframe_mesh_index)
-                                {
-                                    Entry::Occupied(mut entry) => {
-                                        entry.get_mut().push(gpu_instance);
-                                    }
-                                    Entry::Vacant(entry) => {
-                                        entry.insert(vec![gpu_instance]);
-                                    }
-                                }
-                            } else if is_transparent {
-                                let gpu_instance = GpuTransparentMeshInstance {
-                                    color,
-                                    model_transform: transform,
-                                };
-                                transparent_meshes.push((
-                                    mesh_index,
-                                    gpu_instance,
-                                    dist_sq_from_player,
-                                ));
-                            } else {
-                                let gpu_instance = GpuUnlitMeshInstance {
-                                    color,
-                                    model_transform: transform,
-                                };
-                                match unlit_mesh_index_to_gpu_instances.entry(mesh_index) {
-                                    Entry::Occupied(mut entry) => {
-                                        entry.get_mut().push(gpu_instance);
-                                    }
-                                    Entry::Vacant(entry) => {
-                                        entry.insert(vec![gpu_instance]);
-                                    }
+                                Entry::Vacant(entry) => {
+                                    entry.insert(vec![gpu_instance]);
                                 }
                             }
                         }

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -629,7 +629,8 @@ impl BaseRenderer {
         surface_config.alpha_mode = wgpu::CompositeAlphaMode::Auto;
         surface_config.present_mode = wgpu::PresentMode::AutoVsync;
         surface_config.view_formats = vec![surface_config.format.add_srgb_suffix()];
-        // surface_config.desired_maximum_frame_latency = 1; // TODO: framerate drops below monitor refresh rate if this is used without a frame limit
+        // this caused problems on Windows on dx12 and vulkan..
+        surface_config.desired_maximum_frame_latency = 1;
         surface.configure(&base.device, &surface_config);
 
         let capabilities = surface.get_capabilities(&base.adapter);

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -627,8 +627,9 @@ impl BaseRenderer {
         surface_config.usage = wgpu::TextureUsages::RENDER_ATTACHMENT;
         // surface_config.format = wgpu::TextureFormat::Bgra8UnormSrgb;
         surface_config.alpha_mode = wgpu::CompositeAlphaMode::Auto;
-        surface_config.present_mode = wgpu::PresentMode::AutoVsync;
+        surface_config.present_mode = wgpu::PresentMode::Mailbox;
         surface_config.view_formats = vec![surface_config.format.add_srgb_suffix()];
+        surface_config.desired_maximum_frame_latency = 1;
         surface.configure(&base.device, &surface_config);
 
         let capabilities = surface.get_capabilities(&base.adapter);
@@ -3376,7 +3377,7 @@ impl Renderer {
 
     pub fn set_vsync(&self, vsync: bool, surface_data: &mut SurfaceData) {
         let new_present_mode = if vsync {
-            wgpu::PresentMode::AutoVsync
+            wgpu::PresentMode::Mailbox
         } else {
             wgpu::PresentMode::AutoNoVsync
         };

--- a/ikari/src/renderer.rs
+++ b/ikari/src/renderer.rs
@@ -58,7 +58,6 @@ pub const POINT_LIGHT_SHADOW_MAP_FRUSTUM_NEAR_PLANE: f32 = 0.1;
 pub const POINT_LIGHT_SHADOW_MAP_FRUSTUM_FAR_PLANE: f32 = 1000.0;
 pub const POINT_LIGHT_SHADOW_MAP_RESOLUTION: u32 = 1024;
 pub const DIRECTIONAL_LIGHT_SHADOW_MAP_RESOLUTION: u32 = 2048;
-// pub const DIRECTIONAL_LIGHT_SHADOW_MAP_RESOLUTION: u32 = 512;
 pub const POINT_LIGHT_SHOW_MAP_COUNT: u32 = 2;
 pub const DIRECTIONAL_LIGHT_SHOW_MAP_COUNT: u32 = 2;
 pub const DIRECTIONAL_LIGHT_PROJ_BOX_LENGTH: f32 = 50.0;
@@ -631,6 +630,7 @@ impl BaseRenderer {
         surface_config.present_mode = wgpu::PresentMode::AutoVsync;
         surface_config.view_formats = vec![surface_config.format.add_srgb_suffix()];
         // this caused problems on Windows on dx12 and vulkan..
+        // TODO: see if those problems still persist with profiling disabled
         // surface_config.desired_maximum_frame_latency = 1;
         surface.configure(&base.device, &surface_config);
 
@@ -3412,7 +3412,6 @@ impl Renderer {
             .unwrap_or_else(|| surface_data.surface_config.clone());
 
         if new_surface_config.width == 0 || new_surface_config.height == 0 {
-            // log::info!("1");
             return false;
         }
 
@@ -3437,7 +3436,6 @@ impl Renderer {
         let render_scale_changed = current_render_scale != new_render_scale;
 
         if !surface_config_changed && !render_scale_changed && !force_reconfigure {
-            // log::info!("2");
             return false;
         }
 
@@ -3451,7 +3449,6 @@ impl Renderer {
             .configure(&self.base.device, &surface_data.surface_config);
 
         if !surface_resized && !render_scale_changed {
-            // log::info!("3");
             return false;
         }
 
@@ -3738,7 +3735,6 @@ impl Renderer {
             })
             .collect::<Vec<_>>();
 
-        // log::info!("4");
         surface_resized
     }
 

--- a/ikari/src/texture.rs
+++ b/ikari/src/texture.rs
@@ -289,8 +289,8 @@ impl Texture {
         label: &str,
     ) -> Self {
         let size = wgpu::Extent3d {
-            width: ((width as f32 * render_scale.sqrt()).round() as u32).max(1),
-            height: ((height as f32 * render_scale.sqrt()).round() as u32).max(1),
+            width: apply_render_scale(width, render_scale),
+            height: apply_render_scale(height, render_scale),
             depth_or_array_layers: 1,
         };
         let texture = base_renderer
@@ -391,8 +391,8 @@ impl Texture {
         label: &str,
     ) -> Self {
         let size = wgpu::Extent3d {
-            width: ((width as f32 * render_scale.sqrt()).round() as u32).max(1),
-            height: ((height as f32 * render_scale.sqrt()).round() as u32).max(1),
+            width: apply_render_scale(width, render_scale),
+            height: apply_render_scale(height, render_scale),
             depth_or_array_layers: 1,
         };
         let texture = base_renderer
@@ -1247,6 +1247,10 @@ impl Texture {
             size,
         }
     }
+}
+
+pub fn apply_render_scale(dimension: u32, render_scale: f32) -> u32 {
+    ((dimension as f32 * render_scale.sqrt()).round() as u32).max(1)
 }
 
 #[profiling::function]

--- a/ikari/src/time_tracker.rs
+++ b/ikari/src/time_tracker.rs
@@ -12,12 +12,14 @@ pub struct TimeTracker {
 pub struct FrameInstants {
     pub start: Instant,
     pub update_done: Option<Instant>,
+    pub get_surface_done: Option<Instant>,
     pub render_done: Option<Instant>,
 }
 
 #[derive(Debug, Copy, Clone)]
 pub struct FrameDurations {
     pub total: Duration,
+    pub get_surface: Option<Duration>,
     pub update: Option<Duration>,
     pub render: Option<Duration>,
 }
@@ -26,7 +28,9 @@ impl FrameInstants {
     pub fn new(start: Instant) -> Self {
         Self {
             start,
+            get_surface_done: None,
             update_done: None,
+
             render_done: None,
         }
     }
@@ -48,6 +52,12 @@ impl TimeTracker {
         }
     }
 
+    pub(crate) fn on_get_surface_completed(&mut self) {
+        if let Some(current_frame) = self.current_frame.as_mut() {
+            current_frame.get_surface_done = Some(Instant::now());
+        }
+    }
+
     pub(crate) fn on_render_completed(&mut self) {
         if let Some(current_frame) = self.current_frame.as_mut() {
             current_frame.render_done = Some(Instant::now());
@@ -64,9 +74,24 @@ impl TimeTracker {
                 last_frame,
                 FrameDurations {
                     total: current_frame.start - last_frame.start,
-                    update: last_frame
-                        .update_done
-                        .map(|update_done| update_done - last_frame.start),
+                    // update: last_frame
+                    //     .update_done
+                    //     .map(|update_done| update_done - last_frame.start),
+                    // get_surface: match (last_frame.update_done, last_frame.get_surface_done) {
+                    //     (Some(update_done), Some(get_surface_done)) => {
+                    //         Some(get_surface_done - update_done)
+                    //     }
+                    //     _ => None,
+                    // },
+                    get_surface: last_frame
+                        .get_surface_done
+                        .map(|get_surface_done| get_surface_done - last_frame.start),
+                    update: match (last_frame.get_surface_done, last_frame.update_done) {
+                        (Some(get_surface_done), Some(update_done)) => {
+                            Some(update_done - get_surface_done)
+                        }
+                        _ => None,
+                    },
                     render: match (last_frame.update_done, last_frame.render_done) {
                         (Some(update_done), Some(render_done)) => Some(render_done - update_done),
                         _ => None,

--- a/ikari/src/time_tracker.rs
+++ b/ikari/src/time_tracker.rs
@@ -5,6 +5,7 @@ use crate::time::Instant;
 pub struct TimeTracker {
     first_frame_start: Option<Instant>,
     current_frame: Option<FrameInstants>,
+    current_frame_index: usize,
     last_frame: Option<FrameInstants>,
 }
 
@@ -44,7 +45,9 @@ impl TimeTracker {
 
         if let Some(current_frame) = self.current_frame {
             self.last_frame = Some(current_frame);
+            self.current_frame_index += 1;
         }
+
         self.current_frame = Some(FrameInstants::new(Instant::now()));
     }
 
@@ -70,6 +73,10 @@ impl TimeTracker {
         if let Some(current_frame) = self.current_frame.as_mut() {
             current_frame.get_surface_done = Some(Instant::now());
         }
+    }
+
+    pub fn current_frame_index(&self) -> usize {
+        self.current_frame_index
     }
 
     pub fn global_time(&self) -> Option<Duration> {

--- a/ikari/src/time_tracker.rs
+++ b/ikari/src/time_tracker.rs
@@ -90,13 +90,16 @@ impl TimeTracker {
                 last_frame,
                 FrameDurations {
                     total: current_frame.start - last_frame.start,
-                    sleep_and_inputs: option_delta(
+                    sleep_and_inputs: option_subtract(
                         last_frame.sleep_and_inputs,
                         Some(last_frame.start),
                     ),
-                    update: option_delta(last_frame.update_done, last_frame.sleep_and_inputs),
-                    render: option_delta(last_frame.render_done, last_frame.update_done),
-                    get_surface: option_delta(last_frame.get_surface_done, last_frame.render_done),
+                    update: option_subtract(last_frame.update_done, last_frame.sleep_and_inputs),
+                    render: option_subtract(last_frame.render_done, last_frame.update_done),
+                    get_surface: option_subtract(
+                        last_frame.get_surface_done,
+                        last_frame.render_done,
+                    ),
                 },
             )),
             _ => None,
@@ -118,7 +121,7 @@ impl TimeTracker {
     }
 }
 
-fn option_delta(end: Option<Instant>, start: Option<Instant>) -> Option<Duration> {
+fn option_subtract(end: Option<Instant>, start: Option<Instant>) -> Option<Duration> {
     match (end, start) {
         (Some(end), Some(start)) => Some(end - start),
         _ => None,

--- a/ikari/src/web_canvas_manager.rs
+++ b/ikari/src/web_canvas_manager.rs
@@ -10,8 +10,7 @@ mod native {
             Self
         }
 
-        pub fn on_update(&self, size: winit::dpi::PhysicalSize<u32>) {}
-        // pub fn on_update(&self, _event: &winit::event::Event<()>) {}
+        pub fn on_update(&self, _event: &winit::event::Event<()>) {}
     }
 }
 
@@ -20,7 +19,6 @@ mod web {
     use std::sync::Arc;
     use wasm_bindgen::prelude::*;
     use winit::event::Event;
-    use winit::event::WindowEvent;
     use winit::window::Window;
 
     pub struct WebCanvasManager {
@@ -43,12 +41,7 @@ mod web {
             }
         }
 
-        pub fn on_update(&self, size: winit::dpi::PhysicalSize<u32>) {
-            // let new_size = winit::dpi::PhysicalSize::new(
-            //     (size.width as f64 * self.window.scale_factor()) as u32,
-            //     (size.height as f64 * self.window.scale_factor()) as u32,
-            // );
-            // self.window.request_inner_size(size);
+        pub fn on_update(&self, event: &Event<()>) {
             let new_size = winit::dpi::PhysicalSize::new(
                 (self.canvas_container.offset_width() as f64 * self.window.scale_factor()) as u32,
                 (self.canvas_container.offset_height() as f64 * self.window.scale_factor()) as u32,
@@ -56,45 +49,11 @@ mod web {
             if self.window.inner_size() != new_size {
                 let _resized_immediately = self.window.request_inner_size(new_size);
             }
+
+            if matches!(event, Event::LoopExiting) {
+                self.canvas_container.remove();
+            }
         }
-
-        // pub fn on_update(&self, event: &Event<()>) {
-        //     match event {
-        //         Event::WindowEvent {
-        //             event: WindowEvent::RedrawRequested,
-        //             ..
-        //         } => {
-        //             self.resize();
-        //         }
-        //         Event::LoopExiting => {
-        //             self.canvas_container.remove();
-        //         }
-        //         Event::WindowEvent {
-        //             event, window_id, ..
-        //         } if *window_id == self.window.id() => {
-        //             match &event {
-        //                 WindowEvent::Resized(_) => {
-        //                     self.resize();
-        //                 }
-        //                 WindowEvent::ScaleFactorChanged { .. } => {
-        //                     self.resize();
-        //                 }
-        //                 _ => {}
-        //             };
-        //         }
-        //         _ => {}
-        //     };
-        // }
-
-        // fn resize(&self) {
-        //     let new_size = winit::dpi::PhysicalSize::new(
-        //         (self.canvas_container.offset_width() as f64 * self.window.scale_factor()) as u32,
-        //         (self.canvas_container.offset_height() as f64 * self.window.scale_factor()) as u32,
-        //     );
-        //     if self.window.inner_size() != new_size {
-        //         let _resized_immediately = self.window.request_inner_size(new_size);
-        //     }
-        // }
     }
 }
 

--- a/ikari/src/web_canvas_manager.rs
+++ b/ikari/src/web_canvas_manager.rs
@@ -10,7 +10,8 @@ mod native {
             Self
         }
 
-        pub fn on_update(&self, _event: &winit::event::Event<()>) {}
+        pub fn on_update(&self, size: winit::dpi::PhysicalSize<u32>) {}
+        // pub fn on_update(&self, _event: &winit::event::Event<()>) {}
     }
 }
 
@@ -23,8 +24,8 @@ mod web {
     use winit::window::Window;
 
     pub struct WebCanvasManager {
-        window: Arc<Window>,
-        canvas_container: web_sys::HtmlElement,
+        pub window: Arc<Window>,
+        pub canvas_container: web_sys::HtmlElement,
     }
 
     impl WebCanvasManager {
@@ -42,35 +43,12 @@ mod web {
             }
         }
 
-        pub fn on_update(&self, event: &Event<()>) {
-            match event {
-                Event::WindowEvent {
-                    event: WindowEvent::RedrawRequested,
-                    ..
-                } => {
-                    self.resize();
-                }
-                Event::LoopExiting => {
-                    self.canvas_container.remove();
-                }
-                Event::WindowEvent {
-                    event, window_id, ..
-                } if *window_id == self.window.id() => {
-                    match &event {
-                        WindowEvent::Resized(_) => {
-                            self.resize();
-                        }
-                        WindowEvent::ScaleFactorChanged { .. } => {
-                            self.resize();
-                        }
-                        _ => {}
-                    };
-                }
-                _ => {}
-            };
-        }
-
-        fn resize(&self) {
+        pub fn on_update(&self, size: winit::dpi::PhysicalSize<u32>) {
+            // let new_size = winit::dpi::PhysicalSize::new(
+            //     (size.width as f64 * self.window.scale_factor()) as u32,
+            //     (size.height as f64 * self.window.scale_factor()) as u32,
+            // );
+            // self.window.request_inner_size(size);
             let new_size = winit::dpi::PhysicalSize::new(
                 (self.canvas_container.offset_width() as f64 * self.window.scale_factor()) as u32,
                 (self.canvas_container.offset_height() as f64 * self.window.scale_factor()) as u32,
@@ -79,6 +57,44 @@ mod web {
                 let _resized_immediately = self.window.request_inner_size(new_size);
             }
         }
+
+        // pub fn on_update(&self, event: &Event<()>) {
+        //     match event {
+        //         Event::WindowEvent {
+        //             event: WindowEvent::RedrawRequested,
+        //             ..
+        //         } => {
+        //             self.resize();
+        //         }
+        //         Event::LoopExiting => {
+        //             self.canvas_container.remove();
+        //         }
+        //         Event::WindowEvent {
+        //             event, window_id, ..
+        //         } if *window_id == self.window.id() => {
+        //             match &event {
+        //                 WindowEvent::Resized(_) => {
+        //                     self.resize();
+        //                 }
+        //                 WindowEvent::ScaleFactorChanged { .. } => {
+        //                     self.resize();
+        //                 }
+        //                 _ => {}
+        //             };
+        //         }
+        //         _ => {}
+        //     };
+        // }
+
+        // fn resize(&self) {
+        //     let new_size = winit::dpi::PhysicalSize::new(
+        //         (self.canvas_container.offset_width() as f64 * self.window.scale_factor()) as u32,
+        //         (self.canvas_container.offset_height() as f64 * self.window.scale_factor()) as u32,
+        //     );
+        //     if self.window.inner_size() != new_size {
+        //         let _resized_immediately = self.window.request_inner_size(new_size);
+        //     }
+        // }
     }
 }
 

--- a/ikari/src/web_canvas_manager.rs
+++ b/ikari/src/web_canvas_manager.rs
@@ -22,8 +22,8 @@ mod web {
     use winit::window::Window;
 
     pub struct WebCanvasManager {
-        pub window: Arc<Window>,
-        pub canvas_container: web_sys::HtmlElement,
+        window: Arc<Window>,
+        canvas_container: web_sys::HtmlElement,
     }
 
     impl WebCanvasManager {


### PR DESCRIPTION
- move render scale setting into UI
- add trait that allows the ui overlay to process window events directly
- add color switching to the cursor overlay debug
- add frame counter
- adjust options menu item spacing
- add framerate limiter
  - rearrange the gameloop so that the sleep is the first thing that happens in the frame
  - decouple surface reconfigure and resize, defer them to happen at the right time in the frame
  - surface resize event gets sent in lockstep with surface resizing
  - continues processing inputs while sleeping to reduce input latency